### PR TITLE
prometheus: replace not allowed character - with _ in metric names

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -25,7 +25,7 @@ func NewPrometheusSink() (*PrometheusSink, error) {
 
 func (p *PrometheusSink) flattenKey(parts []string) string {
 	joined := strings.Join(parts, "_")
-	return strings.Replace(strings.Replace(joined, " ", "_", -1), ".", "_", -1)
+	return strings.Replace(strings.Replace(strings.Replace(joined, " ", "_", -1), ".", "_", -1), "-", "_", -1)
 }
 
 func (p *PrometheusSink) SetGauge(parts []string, val float32) {

--- a/prometheus.go
+++ b/prometheus.go
@@ -25,7 +25,10 @@ func NewPrometheusSink() (*PrometheusSink, error) {
 
 func (p *PrometheusSink) flattenKey(parts []string) string {
 	joined := strings.Join(parts, "_")
-	return strings.Replace(strings.Replace(strings.Replace(joined, " ", "_", -1), ".", "_", -1), "-", "_", -1)
+	joined = strings.Replace(joined, " ", "_", -1)
+	joined = strings.Replace(joined, ".", "_", -1)
+	joined = strings.Replace(joined, "-", "_", -1)
+	return joined
 }
 
 func (p *PrometheusSink) SetGauge(parts []string, val float32) {


### PR DESCRIPTION
This is necessary when using hashicorp/raft on a machine whose hostname
contains dashes, like the travis build nodes.