### PR TITLE
adds hostname support to other metric types

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -19,6 +19,9 @@ func (m *Metrics) SetGauge(key []string, val float32) {
 }
 
 func (m *Metrics) EmitKey(key []string, val float32) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "kv", key)
 	}
@@ -29,6 +32,9 @@ func (m *Metrics) EmitKey(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounter(key []string, val float32) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
 	}
@@ -39,6 +45,9 @@ func (m *Metrics) IncrCounter(key []string, val float32) {
 }
 
 func (m *Metrics) AddSample(key []string, val float32) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
 	}
@@ -49,6 +58,9 @@ func (m *Metrics) AddSample(key []string, val float32) {
 }
 
 func (m *Metrics) MeasureSince(key []string, start time.Time) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)
 	}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -66,6 +66,17 @@ func TestMetrics_EmitKey(t *testing.T) {
 	}
 
 	m, met = mockMetric()
+	met.HostName = "test"
+	met.EnableHostname = true
+	met.EmitKey([]string{"key"}, float32(1))
+	if m.keys[0][0] != "test" || m.keys[0][1] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
 	met.EnableTypePrefix = true
 	met.EmitKey([]string{"key"}, float32(1))
 	if m.keys[0][0] != "kv" || m.keys[0][1] != "key" {
@@ -90,6 +101,17 @@ func TestMetrics_IncrCounter(t *testing.T) {
 	m, met := mockMetric()
 	met.IncrCounter([]string{"key"}, float32(1))
 	if m.keys[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	met.HostName = "test"
+	met.EnableHostname = true
+	met.IncrCounter([]string{"key"}, float32(1))
+	if m.keys[0][0] != "test" || m.keys[0][1] != "key" {
 		t.Fatalf("")
 	}
 	if m.vals[0] != 1 {
@@ -128,6 +150,17 @@ func TestMetrics_AddSample(t *testing.T) {
 	}
 
 	m, met = mockMetric()
+	met.HostName = "test"
+	met.EnableHostname = true
+	met.AddSample([]string{"key"}, float32(1))
+	if m.keys[0][0] != "test" || m.keys[0][1] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
 	met.EnableTypePrefix = true
 	met.AddSample([]string{"key"}, float32(1))
 	if m.keys[0][0] != "sample" || m.keys[0][1] != "key" {
@@ -154,6 +187,19 @@ func TestMetrics_MeasureSince(t *testing.T) {
 	n := time.Now()
 	met.MeasureSince([]string{"key"}, n)
 	if m.keys[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] > 0.1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	met.TimerGranularity = time.Millisecond
+	n = time.Now()
+	met.HostName = "test"
+	met.EnableHostname = true
+	met.MeasureSince([]string{"key"}, n)
+	if m.keys[0][0] != "test" || m.keys[0][1] != "key" {
 		t.Fatalf("")
 	}
 	if m.vals[0] > 0.1 {


### PR DESCRIPTION
Only Gauge types had tests/implementation for Hostname support. This fixes that.