### PR TITLE
add LastUpdated field to AggregateSample

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -65,11 +65,12 @@ func NewIntervalMetrics(intv time.Time) *IntervalMetrics {
 // AggregateSample is used to hold aggregate metrics
 // about a sample
 type AggregateSample struct {
-	Count int     // The count of emitted pairs
-	Sum   float64 // The sum of values
-	SumSq float64 // The sum of squared values
-	Min   float64 // Minimum value
-	Max   float64 // Maximum value
+	Count       int       // The count of emitted pairs
+	Sum         float64   // The sum of values
+	SumSq       float64   // The sum of squared values
+	Min         float64   // Minimum value
+	Max         float64   // Maximum value
+	LastUpdated time.Time // When value was last updated
 }
 
 // Computes a Stddev of the values
@@ -101,16 +102,17 @@ func (a *AggregateSample) Ingest(v float64) {
 	if v > a.Max || a.Count == 1 {
 		a.Max = v
 	}
+	a.LastUpdated = time.Now()
 }
 
 func (a *AggregateSample) String() string {
 	if a.Count == 0 {
 		return "Count: 0"
 	} else if a.Stddev() == 0 {
-		return fmt.Sprintf("Count: %d Sum: %0.3f", a.Count, a.Sum)
+		return fmt.Sprintf("Count: %d Sum: %0.3f LastUpdated: %s", a.Count, a.Sum, a.LastUpdated)
 	} else {
-		return fmt.Sprintf("Count: %d Min: %0.3f Mean: %0.3f Max: %0.3f Stddev: %0.3f Sum: %0.3f",
-			a.Count, a.Min, a.Mean(), a.Max, a.Stddev(), a.Sum)
+		return fmt.Sprintf("Count: %d Min: %0.3f Mean: %0.3f Max: %0.3f Stddev: %0.3f Sum: %0.3f LastUpdated: %s",
+			a.Count, a.Min, a.Mean(), a.Max, a.Stddev(), a.Sum, a.LastUpdated)
 	}
 }
 

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -63,6 +63,15 @@ func TestInmemSink(t *testing.T) {
 		t.Fatalf("bad val: %v", agg)
 	}
 
+	if agg.LastUpdated.IsZero() {
+		t.Fatalf("agg.LastUpdated is not set: %v", agg)
+	}
+
+	diff := time.Now().Sub(agg.LastUpdated).Seconds()
+	if diff > 1 {
+		t.Fatalf("time diff too great: %f", diff)
+	}
+
 	if agg = intvM.Samples["foo.bar"]; agg == nil {
 		t.Fatalf("missing sample")
 	}


### PR DESCRIPTION
I frequently find it necessary to keep track of when the last sample was added in an `IntervalMetric`. This PR adds a `LastUpdated` field to `AggregateSample` and is updated whenever `Ingest()` is called.

```go
s := im.Samples["foo.bar"]
rate := (s.Max - s.Min)/(s.LastUpdated.Sub(im.Interval).Seconds())
```