### PR TITLE
Prepend the hostname to every metric with `EnableHostName` set

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -6,11 +6,11 @@ import (
 )
 
 func (m *Metrics) SetGauge(key []string, val float32) {
-	if m.HostName != "" && m.EnableHostname {
-		key = insert(0, m.HostName, key)
-	}
 	if m.EnableTypePrefix {
 		key = insert(0, "gauge", key)
+	}
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
@@ -19,11 +19,11 @@ func (m *Metrics) SetGauge(key []string, val float32) {
 }
 
 func (m *Metrics) EmitKey(key []string, val float32) {
-	if m.HostName != "" && m.EnableHostname {
-		key = insert(0, m.HostName, key)
-	}
 	if m.EnableTypePrefix {
 		key = insert(0, "kv", key)
+	}
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
@@ -32,11 +32,11 @@ func (m *Metrics) EmitKey(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounter(key []string, val float32) {
-	if m.HostName != "" && m.EnableHostname {
-		key = insert(0, m.HostName, key)
-	}
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
+	}
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
@@ -45,11 +45,11 @@ func (m *Metrics) IncrCounter(key []string, val float32) {
 }
 
 func (m *Metrics) AddSample(key []string, val float32) {
-	if m.HostName != "" && m.EnableHostname {
-		key = insert(0, m.HostName, key)
-	}
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
+	}
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
@@ -58,11 +58,11 @@ func (m *Metrics) AddSample(key []string, val float32) {
 }
 
 func (m *Metrics) MeasureSince(key []string, start time.Time) {
-	if m.HostName != "" && m.EnableHostname {
-		key = insert(0, m.HostName, key)
-	}
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)
+	}
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)

--- a/metrics.go
+++ b/metrics.go
@@ -19,6 +19,9 @@ func (m *Metrics) SetGauge(key []string, val float32) {
 }
 
 func (m *Metrics) EmitKey(key []string, val float32) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "kv", key)
 	}
@@ -29,6 +32,9 @@ func (m *Metrics) EmitKey(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounter(key []string, val float32) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
 	}
@@ -39,6 +45,9 @@ func (m *Metrics) IncrCounter(key []string, val float32) {
 }
 
 func (m *Metrics) AddSample(key []string, val float32) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
 	}
@@ -49,6 +58,9 @@ func (m *Metrics) AddSample(key []string, val float32) {
 }
 
 func (m *Metrics) MeasureSince(key []string, start time.Time) {
+	if m.HostName != "" && m.EnableHostname {
+		key = insert(0, m.HostName, key)
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)
 	}


### PR DESCRIPTION
For some reason, the `EnableHostName` option exists, but isn't used
except for `SetGauge`. This causes most metrics to be in the wrong
location.

Expanding this feature to work for the rest of the functions.
