### PR TITLE
Revert commit b79a89c to fix tests

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -36,7 +36,7 @@ type IntervalMetrics struct {
 
 	// The start time of the interval
 	Interval time.Time
-r
+
 	// Gauges maps the key to the last set value
 	Gauges map[string]float32
 

--- a/inmem.go
+++ b/inmem.go
@@ -36,7 +36,7 @@ type IntervalMetrics struct {
 
 	// The start time of the interval
 	Interval time.Time
-
+r
 	// Gauges maps the key to the last set value
 	Gauges map[string]float32
 
@@ -123,11 +123,12 @@ func (a *AggregateSample) String() string {
 // NewInmemSink is used to construct a new in-memory sink.
 // Uses an aggregation interval and maximum retention period.
 func NewInmemSink(interval, retain time.Duration) *InmemSink {
+	rateTimeUnit := time.Second
 	i := &InmemSink{
 		interval:     interval,
 		retain:       retain,
 		maxIntervals: int(retain / interval),
-		rateDenom: float64(interval / time.Second),
+		rateDenom: float64(interval.Nanoseconds()) / float64(rateTimeUnit.Nanoseconds()),
 	}
 	i.intervals = make([]*IntervalMetrics, 0, i.maxIntervals)
 	return i


### PR DESCRIPTION
The code cleanup commit in b79a89c breaks the unit tests.  In particular rateDenom becomes zero if nanoseconds are not used for the calculation causing the Rate to become +Inf.  This may effect non-test code as well.