### PR TITLE
ignore feature using syscall for appengine users

### DIFF
--- a/const_unix.go
+++ b/const_unix.go
@@ -1,4 +1,5 @@
 // +build !windows
+// +build !appengine
 
 package metrics
 

--- a/const_windows.go
+++ b/const_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+// +build !appengine
 
 package metrics
 

--- a/inmem_signal.go
+++ b/inmem_signal.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package metrics
 
 import (

--- a/inmem_signal_test.go
+++ b/inmem_signal_test.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package metrics
 
 import (


### PR DESCRIPTION
go-metrics is imported from goa ( https://github.com/goadesign/goa ) and some users (including me) use appengine to serve APIs.

Build for appengine failed because import of `syscall` package is not allowed.
So for the appengine users, ignoring the InmemSignal feature make them happy.