### PR TITLE
Add setting to ignore for use in GAE

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ When a signal comes in, output like the following will be dumped to stderr:
     [2014-01-28 14:57:33.04 -0800 PST][C] 'baz': Count: 3 Min: 1.000 Mean: 41.000 Max: 80.000 Stddev: 39.509
     [2014-01-28 14:57:33.04 -0800 PST][S] 'method.wow': Count: 3 Min: 22.000 Mean: 54.667 Max: 100.000 Stddev: 40.513
 
+Behavior on GAE
+===============
+
+In the GAE of GCP's PaaS, the following files are ignored.  
+The reason is that the `syscall` package is not allowed in GAE.
+
+- const_unix.go 
+- const_windows.go 
+- inmem_signal.go 
+- inmem_signal_test.go 

--- a/const_unix.go
+++ b/const_unix.go
@@ -1,4 +1,5 @@
 // +build !windows
+// +build !appengine
 
 package metrics
 

--- a/const_windows.go
+++ b/const_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+// +build !appengine
 
 package metrics
 

--- a/inmem_signal.go
+++ b/inmem_signal.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package metrics
 
 import (

--- a/inmem_signal_test.go
+++ b/inmem_signal_test.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package metrics
 
 import (


### PR DESCRIPTION
for 
https://github.com/armon/go-metrics/issues/38
https://github.com/armon/go-metrics/pull/45

Go-app-builder: Failed parsing input: parser: bad import "syscall" in ...
This problem is a problem occurring in GAE which is PaaS of GCP.
Two packages, syscall and unsafe, are not allowed to be used on GAE.
So, you need a description not included in the build.

The target files are as follows.
- const_unix.go 
- const_windows.go 
- inmem_signal.go 
- inmem_signal_test.go 

Since my repository is applying changes, https://github.com/armon/go-metrics/pull/45 commits are included.