### PR TITLE
Introduce unified URL-based sink factory function

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -125,21 +125,18 @@ func (a *AggregateSample) String() string {
 // (and tested) from NewMetricSinkFromURL.
 func NewInmemSinkFromURL(u *url.URL) (MetricSink, error) {
 	params := u.Query()
-	if len(params["interval"]) < 1 {
-		return nil, fmt.Errorf("missing interval query param")
-	}
-	interval, err := time.ParseDuration(params["interval"][0])
+
+	interval, err := time.ParseDuration(params.Get("interval"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Bad 'interval' param: %s", err)
 	}
-	if len(params["duration"]) < 1 {
-		return nil, fmt.Errorf("missing duration query param")
-	}
-	duration, err := time.ParseDuration(params["duration"][0])
+
+	retain, err := time.ParseDuration(params.Get("retain"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Bad 'retain' param: %s", err)
 	}
-	return NewInmemSink(interval, duration), nil
+
+	return NewInmemSink(interval, retain), nil
 }
 
 // NewInmemSink is used to construct a new in-memory sink.

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -121,7 +121,7 @@ func TestNewInmemSinkFromURL(t *testing.T) {
 			expectErr: "Bad 'interval' param",
 		},
 		{
-			desc:      "interval must be a duratgion",
+			desc:      "interval must be a duration",
 			input:     "inmem://?retain=30s&interval=HIYA",
 			expectErr: "Bad 'interval' param",
 		},

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"math"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -99,9 +101,78 @@ func TestInmemSink(t *testing.T) {
 	}
 }
 
+func TestNewInmemSinkFromURL(t *testing.T) {
+	for _, tc := range []struct {
+		desc           string
+		input          string
+		expectErr      string
+		expectInterval time.Duration
+		expectRetain   time.Duration
+	}{
+		{
+			desc:           "interval and duration are set via query params",
+			input:          "inmem://?interval=11s&retain=22s",
+			expectInterval: duration(t, "11s"),
+			expectRetain:   duration(t, "22s"),
+		},
+		{
+			desc:      "interval is required",
+			input:     "inmem://?retain=22s",
+			expectErr: "Bad 'interval' param",
+		},
+		{
+			desc:      "interval must be a duratgion",
+			input:     "inmem://?retain=30s&interval=HIYA",
+			expectErr: "Bad 'interval' param",
+		},
+		{
+			desc:      "retain is required",
+			input:     "inmem://?interval=30s",
+			expectErr: "Bad 'retain' param",
+		},
+		{
+			desc:      "retain must be a valid duration",
+			input:     "inmem://?interval=30s&retain=HELLO",
+			expectErr: "Bad 'retain' param",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			u, err := url.Parse(tc.input)
+			if err != nil {
+				t.Fatalf("error parsing URL: %s", err)
+			}
+			ms, err := NewInmemSinkFromURL(u)
+			if tc.expectErr != "" {
+				if !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("expected err: %q, to contain: %q", err, tc.expectErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected err: %s", err)
+				}
+				is := ms.(*InmemSink)
+				if is.interval != tc.expectInterval {
+					t.Fatalf("expected interval %s, got: %s", tc.expectInterval, is.interval)
+				}
+				if is.retain != tc.expectRetain {
+					t.Fatalf("expected retain %s, got: %s", tc.expectRetain, is.retain)
+				}
+			}
+		})
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a
 	}
 	return b
+}
+
+func duration(t *testing.T, s string) time.Duration {
+	dur, err := time.ParseDuration(s)
+	if err != nil {
+		t.Fatalf("error parsing duration: %s", err)
+	}
+	return dur
 }

--- a/sink.go
+++ b/sink.go
@@ -1,5 +1,11 @@
 package metrics
 
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
 // The MetricSink interface is used to transmit metrics information
 // to an external system
 type MetricSink interface {
@@ -49,4 +55,45 @@ func (fh FanoutSink) AddSample(key []string, val float32) {
 	for _, s := range fh {
 		s.AddSample(key, val)
 	}
+}
+
+// sinkURLFactoryFunc is an generic interface around the *SinkFromURL() function provided
+// by each sink type
+type sinkURLFactoryFunc func(*url.URL) (MetricSink, error)
+
+// sinkRegistry supports the generic NewMetricSink function by mapping URL
+// schemes to metric sink factory functions
+var sinkRegistry = map[string]sinkURLFactoryFunc{
+	"statsd":   NewStatsdSinkFromURL,
+	"statsite": NewStatsiteSinkFromURL,
+	"inmem":    NewInmemSinkFromURL,
+}
+
+// NewMetricSinkFromURL allows a generic URL input to configure any of the
+// supported sinks. The scheme of the URL identifies the type of the sink, the
+// and query parameters are used to set options.
+//
+// "statsd://" - Initializes a StatsdSink. The host and port are passed through
+// as the "addr" of the sink
+//
+// "statsite://" - Initializes a StatsiteSink. The host and port become the
+// "addr" of the sink
+//
+// "inmem://" - Initializes an InmemSink. The host and port are ignored. The
+// "interval" and "duration" query parameters must be specified with valid
+// durations, see NewInmemSink for details.
+func NewMetricSinkFromURL(urlStr string) (MetricSink, error) {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	sinkName := strings.ToLower(u.Scheme)
+	sinkURLFactoryFunc := sinkRegistry[sinkName]
+	if sinkURLFactoryFunc == nil {
+		return nil, fmt.Errorf(
+			"cannot create metric sink, unrecognized sink name: %q", sinkName)
+	}
+
+	return sinkURLFactoryFunc(u)
 }

--- a/sink.go
+++ b/sink.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"fmt"
 	"net/url"
-	"strings"
 )
 
 // The MetricSink interface is used to transmit metrics information
@@ -88,11 +87,10 @@ func NewMetricSinkFromURL(urlStr string) (MetricSink, error) {
 		return nil, err
 	}
 
-	sinkName := strings.ToLower(u.Scheme)
-	sinkURLFactoryFunc := sinkRegistry[sinkName]
+	sinkURLFactoryFunc := sinkRegistry[u.Scheme]
 	if sinkURLFactoryFunc == nil {
 		return nil, fmt.Errorf(
-			"cannot create metric sink, unrecognized sink name: %q", sinkName)
+			"cannot create metric sink, unrecognized sink name: %q", u.Scheme)
 	}
 
 	return sinkURLFactoryFunc(u)

--- a/sink_test.go
+++ b/sink_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,75 +121,48 @@ func TestFanoutSink_Sample(t *testing.T) {
 }
 
 func TestNewMetricSinkFromURL(t *testing.T) {
-	cases := map[string]struct {
-		Input string
-		Check func(MetricSink, error) error
+	for _, tc := range []struct {
+		desc      string
+		input     string
+		expect    reflect.Type
+		expectErr string
 	}{
-		"statsd": {
-			Input: "statsd://someserver:123",
-			Check: func(ms MetricSink, err error) error {
+		{
+			desc:   "statsd scheme yields a StatsdSink",
+			input:  "statsd://someserver:123",
+			expect: reflect.TypeOf(&StatsdSink{}),
+		},
+		{
+			desc:   "statsite scheme yields a StatsiteSink",
+			input:  "statsite://someserver:123",
+			expect: reflect.TypeOf(&StatsiteSink{}),
+		},
+		{
+			desc:   "inmem scheme yields an InmemSink",
+			input:  "inmem://?interval=30s&retain=30s",
+			expect: reflect.TypeOf(&InmemSink{}),
+		},
+		{
+			desc:      "unknown scheme yields an error",
+			input:     "notasink://whatever",
+			expectErr: "unrecognized sink name: \"notasink\"",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ms, err := NewMetricSinkFromURL(tc.input)
+			if tc.expectErr != "" {
+				if !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("expected err: %q to contain: %q", err, tc.expectErr)
+				}
+			} else {
 				if err != nil {
-					return fmt.Errorf("unexpected err: %s", err)
+					t.Fatalf("unexpected err: %s", err)
 				}
-				ss, ok := ms.(*StatsdSink)
-				if !ok {
-					return fmt.Errorf("Response is not a *StatsdSink: %#v", ms)
+				got := reflect.TypeOf(ms)
+				if got != tc.expect {
+					t.Fatalf("expected return type to be %v, got: %v", tc.expect, got)
 				}
-				expectAddr := "someserver:123"
-				if ss.addr != expectAddr {
-					return fmt.Errorf("Expected addr %q, got: %q", expectAddr, ss.addr)
-				}
-				return nil
-			},
-		},
-		"statsite": {
-			Input: "statsite://someserver:123",
-			Check: func(ms MetricSink, err error) error {
-				if err != nil {
-					return fmt.Errorf("unexpected err: %s", err)
-				}
-				ss, ok := ms.(*StatsiteSink)
-				if !ok {
-					return fmt.Errorf("Response is not a *StatsiteSink: %#v", ms)
-				}
-				expectAddr := "someserver:123"
-				if ss.addr != expectAddr {
-					return fmt.Errorf("Expected addr %q, got: %q", expectAddr, ss.addr)
-				}
-				return nil
-			},
-		},
-		"inmem": {
-			Input: "inmem://?interval=30s&duration=30s",
-			Check: func(ms MetricSink, err error) error {
-				if err != nil {
-					return fmt.Errorf("unexpected err: %s", err)
-				}
-				if _, ok := ms.(*InmemSink); !ok {
-					return fmt.Errorf("Response is not a *InmemSink: %#v", ms)
-				}
-				return nil
-			},
-		},
-		"unknown": {
-			Input: "notasink://someserver:123",
-			Check: func(ms MetricSink, err error) error {
-				if err == nil {
-					return fmt.Errorf("expected err, got none")
-				}
-				if !strings.Contains(err.Error(), "unrecognized sink name: \"notasink\"") {
-					return fmt.Errorf("unexpected kind of err: %s", err)
-				}
-				return nil
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		output, err := NewMetricSinkFromURL(tc.Input)
-		resultErr := tc.Check(output, err)
-		if resultErr != nil {
-			t.Errorf("%s: %s", name, resultErr)
-		}
+			}
+		})
 	}
 }

--- a/statsd.go
+++ b/statsd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -21,6 +22,12 @@ const (
 type StatsdSink struct {
 	addr        string
 	metricQueue chan string
+}
+
+// NewStatsdSinkFromURL creates an StatsdSink from a URL. It is used
+// (and tested) from NewMetricSinkFromURL.
+func NewStatsdSinkFromURL(u *url.URL) (MetricSink, error) {
+	return NewStatsdSink(u.Host)
 }
 
 // NewStatsdSink is used to create a new StatsdSink

--- a/statsite.go
+++ b/statsite.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -15,6 +16,12 @@ const (
 	// forever.
 	flushInterval = 100 * time.Millisecond
 )
+
+// NewStatsiteSinkFromURL creates an StatsiteSink from a URL. It is used
+// (and tested) from NewMetricSinkFromURL.
+func NewStatsiteSinkFromURL(u *url.URL) (MetricSink, error) {
+	return NewStatsiteSink(u.Host)
+}
 
 // StatsiteSink provides a MetricSink that can be used with a
 // statsite metrics server


### PR DESCRIPTION
The `NewMetricSinkFromURL` function allows a single string input to
configure any of the supported sink backends. The various pieces of the
URL are interpreted on a per-sink basis, and the generic `MetricSink`
interface is returned.

This is convenient for downstream users of go-metrics that want to
expose sink-agnostic configuration options, but for whom a more
complicated (e.g. HCL-based) config language is too heavy.

Currently the statsd, statsite, and inmem sinks are supported. Support
for the remaining sinks can be added as a follow up.