### PR TITLE
Added NewStatsdSinkWithPrefix function

### DIFF
--- a/statsd_test.go
+++ b/statsd_test.go
@@ -146,3 +146,70 @@ func TestNewStatsdSinkFromURL(t *testing.T) {
 		})
 	}
 }
+
+func TestNewStatsdSinkWithPrefix(t *testing.T) {
+	addr := "127.0.0.1:7524"
+	done := make(chan bool)
+	go func() {
+		lis, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7524})
+		if err != nil {
+			panic(err)
+		}
+		defer lis.Close()
+		buf := make([]byte, 1500)
+		n, err := lis.Read(buf)
+		if err != nil {
+			panic(err)
+		}
+		reader := bufio.NewReader(bytes.NewReader(buf[:n]))
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "some_prefix.gauge:1.000000|g\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "some_prefix.key:2.000000|kv\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "some_prefix.counter:3.000000|c\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "some_prefix.sample:4.000000|ms\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		done <- true
+	}()
+	s, err := NewStatsdSinkWithPrefix(addr, "some_prefix")
+	if err != nil {
+		t.Fatalf("bad error: %v", err)
+	}
+
+	s.SetGauge([]string{"gauge"}, float32(1))
+	s.EmitKey([]string{"key"}, float32(2))
+	s.IncrCounter([]string{"counter"}, float32(3))
+	s.AddSample([]string{"sample"}, float32(4))
+
+	select {
+	case <-done:
+		s.Shutdown()
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+}


### PR DESCRIPTION
`NewStatsdSinkWithPrefix` allows each metric to be sent with a prefix.
Based on https://github.com/peterbourgon/g2s/pull/13

I have noticed that `DogStatsdSink` uses normal `NewDogStatsdSink` and then `SetTags`, so I have no problem with changing this sink to use `SetPrefix` if you think the current solution is not optimal.