### PR TITLE
Add support for labeled metrics

### DIFF
--- a/circonus/circonus.go
+++ b/circonus/circonus.go
@@ -62,7 +62,7 @@ func (s *CirconusSink) SetGauge(key []string, val float32) {
 	s.metrics.SetGauge(flatKey, int64(val))
 }
 
-// SetGauge sets value for a gauge metric
+// SetGaugeWithLabels sets value for a gauge metric with the given labels
 func (s *CirconusSink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.metrics.SetGauge(flatKey, int64(val))
@@ -79,7 +79,7 @@ func (s *CirconusSink) IncrCounter(key []string, val float32) {
 	s.metrics.IncrementByValue(flatKey, uint64(val))
 }
 
-// IncrCounter increments a counter metric
+// IncrCounterWithLabels increments a counter metric with the given labels
 func (s *CirconusSink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.metrics.IncrementByValue(flatKey, uint64(val))
@@ -91,7 +91,7 @@ func (s *CirconusSink) AddSample(key []string, val float32) {
 	s.metrics.RecordValue(flatKey, float64(val))
 }
 
-// AddSample adds a sample to a histogram metric
+// AddSampleWithLabels adds a sample to a histogram metric with the given labels
 func (s *CirconusSink) AddSampleWithLabels(key []string, val float32, labels []metrics.Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.metrics.RecordValue(flatKey, float64(val))

--- a/circonus/circonus.go
+++ b/circonus/circonus.go
@@ -5,6 +5,7 @@ package circonus
 import (
 	"strings"
 
+	"github.com/armon/go-metrics"
 	cgm "github.com/circonus-labs/circonus-gometrics"
 )
 
@@ -61,6 +62,12 @@ func (s *CirconusSink) SetGauge(key []string, val float32) {
 	s.metrics.SetGauge(flatKey, int64(val))
 }
 
+// SetGauge sets value for a gauge metric
+func (s *CirconusSink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.metrics.SetGauge(flatKey, int64(val))
+}
+
 // EmitKey is not implemented in circonus
 func (s *CirconusSink) EmitKey(key []string, val float32) {
 	// NOP
@@ -72,9 +79,21 @@ func (s *CirconusSink) IncrCounter(key []string, val float32) {
 	s.metrics.IncrementByValue(flatKey, uint64(val))
 }
 
+// IncrCounter increments a counter metric
+func (s *CirconusSink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.metrics.IncrementByValue(flatKey, uint64(val))
+}
+
 // AddSample adds a sample to a histogram metric
 func (s *CirconusSink) AddSample(key []string, val float32) {
 	flatKey := s.flattenKey(key)
+	s.metrics.RecordValue(flatKey, float64(val))
+}
+
+// AddSample adds a sample to a histogram metric
+func (s *CirconusSink) AddSampleWithLabels(key []string, val float32, labels []metrics.Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
 	s.metrics.RecordValue(flatKey, float64(val))
 }
 
@@ -89,4 +108,12 @@ func (s *CirconusSink) flattenKey(parts []string) string {
 			return r
 		}
 	}, joined)
+}
+
+// Flattens the key along with labels for formatting, removes spaces
+func (s *CirconusSink) flattenKeyLabels(parts []string, labels []metrics.Label) string {
+	for _, label := range labels {
+		parts = append(parts, label.Value)
+	}
+	return s.flattenKey(parts)
 }

--- a/circonus/circonus_test.go
+++ b/circonus/circonus_test.go
@@ -87,7 +87,7 @@ func TestSetGauge(t *testing.T) {
 		cs.Flush()
 	}()
 
-	expect := "{\"foo`bar\":{\"_type\":\"n\",\"_value\":1}}"
+	expect := "{\"foo`bar\":{\"_type\":\"n\",\"_value\":\"1\"}}"
 	actual := <-q
 
 	if actual != expect {

--- a/circonus/circonus_test.go
+++ b/circonus/circonus_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewCirconusSink(t *testing.T) {
 
 	// test with invalid config (nil)
-	expectedError := errors.New("Invalid check manager configuration (no API token AND no submission url).")
+	expectedError := errors.New("invalid check manager configuration (no API token AND no submission url)")
 	_, err := NewCirconusSink(nil)
 	if err == nil || err.Error() != expectedError.Error() {
 		t.Errorf("Expected an '%#v' error, got '%#v'", expectedError, err)

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -97,9 +97,8 @@ func (s *DogStatsdSink) AddSample(key []string, val float32) {
 	s.AddSampleWithLabels(key, val, nil)
 }
 
-// The following ...WithTags methods correspond to Datadog's Tag extension to Statsd.
+// The following ...WithLabels methods correspond to Datadog's Tag extension to Statsd.
 // http://docs.datadoghq.com/guides/dogstatsd/#tags
-
 func (s *DogStatsdSink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
 	flatKey, tags := s.getFlatkeyAndCombinedLabels(key, labels)
 	rate := 1.0

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -69,6 +69,7 @@ func (s *DogStatsdSink) parseKey(key []string) ([]string, []metrics.Label) {
 	for i, el := range key {
 		if el == hostName {
 			key = append(key[:i], key[i+1:]...)
+			break
 		}
 	}
 

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -1,10 +1,12 @@
 package datadog
 
 import (
-	"fmt"
 	"strings"
 
+	"fmt"
+
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/armon/go-metrics"
 )
 
 // DogStatsdSink provides a MetricSink that can be used
@@ -57,11 +59,11 @@ func (s *DogStatsdSink) flattenKey(parts []string) string {
 	}, joined)
 }
 
-func (s *DogStatsdSink) parseKey(key []string) ([]string, []string) {
+func (s *DogStatsdSink) parseKey(key []string) ([]string, []metrics.Label) {
 	// Since DogStatsd supports dimensionality via tags on metric keys, this sink's approach is to splice the hostname out of the key in favor of a `host` tag
 	// The `host` tag is either forced here, or set downstream by the DogStatsd server
 
-	var tags []string
+	var labels []metrics.Label
 	hostName := s.hostName
 
 	//Splice the hostname out of the key
@@ -72,19 +74,19 @@ func (s *DogStatsdSink) parseKey(key []string) ([]string, []string) {
 	}
 
 	if s.propagateHostname {
-		tags = append(tags, fmt.Sprintf("host:%s", hostName))
+		labels = append(labels, metrics.Label{"host", hostName})
 	}
-	return key, tags
+	return key, labels
 }
 
 // Implementation of methods in the MetricSink interface
 
 func (s *DogStatsdSink) SetGauge(key []string, val float32) {
-	s.SetGaugeWithTags(key, val, []string{})
+	s.SetGaugeWithLabels(key, val, nil)
 }
 
 func (s *DogStatsdSink) IncrCounter(key []string, val float32) {
-	s.IncrCounterWithTags(key, val, []string{})
+	s.IncrCounterWithLabels(key, val, nil)
 }
 
 // EmitKey is not implemented since DogStatsd does not provide a metric type that holds an
@@ -93,33 +95,43 @@ func (s *DogStatsdSink) EmitKey(key []string, val float32) {
 }
 
 func (s *DogStatsdSink) AddSample(key []string, val float32) {
-	s.AddSampleWithTags(key, val, []string{})
+	s.AddSampleWithLabels(key, val, nil)
 }
 
 // The following ...WithTags methods correspond to Datadog's Tag extension to Statsd.
 // http://docs.datadoghq.com/guides/dogstatsd/#tags
 
-func (s *DogStatsdSink) SetGaugeWithTags(key []string, val float32, tags []string) {
-	flatKey, tags := s.getFlatkeyAndCombinedTags(key, tags)
+func (s *DogStatsdSink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
+	flatKey, tags := s.getFlatkeyAndCombinedLabels(key, labels)
 	rate := 1.0
 	s.client.Gauge(flatKey, float64(val), tags, rate)
 }
 
-func (s *DogStatsdSink) IncrCounterWithTags(key []string, val float32, tags []string) {
-	flatKey, tags := s.getFlatkeyAndCombinedTags(key, tags)
+func (s *DogStatsdSink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
+	flatKey, tags := s.getFlatkeyAndCombinedLabels(key, labels)
 	rate := 1.0
 	s.client.Count(flatKey, int64(val), tags, rate)
 }
 
-func (s *DogStatsdSink) AddSampleWithTags(key []string, val float32, tags []string) {
-	flatKey, tags := s.getFlatkeyAndCombinedTags(key, tags)
+func (s *DogStatsdSink) AddSampleWithLabels(key []string, val float32, labels []metrics.Label) {
+	flatKey, tags := s.getFlatkeyAndCombinedLabels(key, labels)
 	rate := 1.0
 	s.client.TimeInMilliseconds(flatKey, float64(val), tags, rate)
 }
 
-func (s *DogStatsdSink) getFlatkeyAndCombinedTags(key []string, tags []string) (flattenedKey string, combinedTags []string) {
-	key, hostTags := s.parseKey(key)
+func (s *DogStatsdSink) getFlatkeyAndCombinedLabels(key []string, labels []metrics.Label) (string, []string) {
+	key, parsedLabels := s.parseKey(key)
 	flatKey := s.flattenKey(key)
-	tags = append(tags, hostTags...)
+	labels = append(labels, parsedLabels...)
+
+	var tags []string
+	for _, label := range labels {
+		if label.Value != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", label.Name, label.Value))
+		} else {
+			tags = append(tags, label.Name)
+		}
+	}
+
 	return flatKey, tags
 }

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -1,9 +1,8 @@
 package datadog
 
 import (
-	"strings"
-
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/armon/go-metrics"

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -46,16 +46,18 @@ func (s *DogStatsdSink) EnableHostNamePropagation() {
 
 func (s *DogStatsdSink) flattenKey(parts []string) string {
 	joined := strings.Join(parts, ".")
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case ':':
-			fallthrough
-		case ' ':
-			return '_'
-		default:
-			return r
-		}
-	}, joined)
+	return strings.Map(sanitize, joined)
+}
+
+func sanitize(r rune) rune {
+	switch r {
+	case ':':
+		fallthrough
+	case ' ':
+		return '_'
+	default:
+		return r
+	}
 }
 
 func (s *DogStatsdSink) parseKey(key []string) ([]string, []metrics.Label) {
@@ -125,6 +127,8 @@ func (s *DogStatsdSink) getFlatkeyAndCombinedLabels(key []string, labels []metri
 
 	var tags []string
 	for _, label := range labels {
+		label.Name = strings.Map(sanitize, label.Name)
+		label.Value = strings.Map(sanitize, label.Value)
 		if label.Value != "" {
 			tags = append(tags, fmt.Sprintf("%s:%s", label.Name, label.Value))
 		} else {

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -65,7 +65,7 @@ func (s *DogStatsdSink) parseKey(key []string) ([]string, []metrics.Label) {
 	var labels []metrics.Label
 	hostName := s.hostName
 
-	//Splice the hostname out of the key
+	// Splice the hostname out of the key
 	for i, el := range key {
 		if el == hostName {
 			key = append(key[:i], key[i+1:]...)

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -54,7 +54,8 @@ var MetricSinkTests = []struct {
 	{"AddSample", []string{"sample", "thing"}, float32(4), EmptyTags, HostnameDisabled, "sample.thing:4.000000|ms"},
 	{"IncrCounter", []string{"count", "me"}, float32(3), EmptyTags, HostnameDisabled, "count.me:3|c"},
 
-	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", "my_value"}}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag:my_value"},
+	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", ""}}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag"},
+	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my tag", "my_value"}}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag:my_value"},
 	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameDisabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value"},
 	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameEnabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
 }

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -1,13 +1,14 @@
 package datadog
 
 import (
-	"fmt"
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/armon/go-metrics"
 )
 
-var EmptyTags []string
+var EmptyTags []metrics.Label
 
 const (
 	DogStatsdAddr    = "127.0.0.1:7254"
@@ -22,14 +23,14 @@ func MockGetHostname() string {
 
 var ParseKeyTests = []struct {
 	KeyToParse        []string
-	Tags              []string
+	Tags              []metrics.Label
 	PropagateHostname bool
 	ExpectedKey       []string
-	ExpectedTags      []string
+	ExpectedTags      []metrics.Label
 }{
 	{[]string{"a", MockGetHostname(), "b", "c"}, EmptyTags, HostnameDisabled, []string{"a", "b", "c"}, EmptyTags},
 	{[]string{"a", "b", "c"}, EmptyTags, HostnameDisabled, []string{"a", "b", "c"}, EmptyTags},
-	{[]string{"a", "b", "c"}, EmptyTags, HostnameEnabled, []string{"a", "b", "c"}, []string{fmt.Sprintf("host:%s", MockGetHostname())}},
+	{[]string{"a", "b", "c"}, EmptyTags, HostnameEnabled, []string{"a", "b", "c"}, []metrics.Label{{"host", MockGetHostname()}}},
 }
 
 var FlattenKeyTests = []struct {
@@ -44,7 +45,7 @@ var MetricSinkTests = []struct {
 	Method            string
 	Metric            []string
 	Value             interface{}
-	Tags              []string
+	Tags              []metrics.Label
 	PropagateHostname bool
 	Expected          string
 }{
@@ -53,13 +54,14 @@ var MetricSinkTests = []struct {
 	{"AddSample", []string{"sample", "thing"}, float32(4), EmptyTags, HostnameDisabled, "sample.thing:4.000000|ms"},
 	{"IncrCounter", []string{"count", "me"}, float32(3), EmptyTags, HostnameDisabled, "count.me:3|c"},
 
-	{"SetGauge", []string{"foo", "baz"}, float32(42), []string{"my_tag:my_value"}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag:my_value"},
-	{"SetGauge", []string{"foo", "bar"}, float32(42), []string{"my_tag:my_value", "other_tag:other_value"}, HostnameDisabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value"},
-	{"SetGauge", []string{"foo", "bar"}, float32(42), []string{"my_tag:my_value", "other_tag:other_value"}, HostnameEnabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
+	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", "my_value"}}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag:my_value"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameDisabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameEnabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
 }
 
-func mockNewDogStatsdSink(addr string, tags []string, tagWithHostname bool) *DogStatsdSink {
+func mockNewDogStatsdSink(addr string, labels []metrics.Label, tagWithHostname bool) *DogStatsdSink {
 	dog, _ := NewDogStatsdSink(addr, MockGetHostname())
+	_, tags := dog.getFlatkeyAndCombinedLabels(nil, labels)
 	dog.SetTags(tags)
 	if tagWithHostname {
 		dog.EnableHostNamePropagation()
@@ -90,7 +92,7 @@ func TestParseKey(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(tags, tt.ExpectedTags) {
-			t.Fatalf("Tag Parsing Failed for %v", tt.KeyToParse)
+			t.Fatalf("Tag Parsing Failed for %v, %v != %v", tt.KeyToParse, tags, tt.ExpectedTags)
 		}
 	}
 }
@@ -124,17 +126,17 @@ func TestTaggableMetrics(t *testing.T) {
 
 	dog := mockNewDogStatsdSink(DogStatsdAddr, EmptyTags, HostnameDisabled)
 
-	dog.AddSampleWithTags([]string{"sample", "thing"}, float32(4), []string{"tagkey:tagvalue"})
+	dog.AddSampleWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4.000000|ms|#tagkey:tagvalue")
 
-	dog.SetGaugeWithTags([]string{"sample", "thing"}, float32(4), []string{"tagkey:tagvalue"})
+	dog.SetGaugeWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4.000000|g|#tagkey:tagvalue")
 
-	dog.IncrCounterWithTags([]string{"sample", "thing"}, float32(4), []string{"tagkey:tagvalue"})
+	dog.IncrCounterWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4|c|#tagkey:tagvalue")
 
-	dog = mockNewDogStatsdSink(DogStatsdAddr, []string{"global"}, HostnameEnabled) // with hostname, global tags
-	dog.IncrCounterWithTags([]string{"sample", "thing"}, float32(4), []string{"tagkey:tagvalue"})
+	dog = mockNewDogStatsdSink(DogStatsdAddr, []metrics.Label{{Name: "global"}}, HostnameEnabled) // with hostname, global tags
+	dog.IncrCounterWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4|c|#global,tagkey:tagvalue,host:test_hostname")
 }
 

--- a/inmem.go
+++ b/inmem.go
@@ -282,8 +282,18 @@ func (i *InmemSink) getInterval() *IntervalMetrics {
 
 // Flattens the key for formatting, removes spaces
 func (i *InmemSink) flattenKey(parts []string) string {
-	joined := strings.Join(parts, ".")
-	return strings.Replace(joined, " ", "_", -1)
+	buf := &bytes.Buffer{}
+	replacer := strings.NewReplacer(" ", "_")
+
+	if len(parts) > 0 {
+		replacer.WriteString(buf, parts[0])
+	}
+	for _, part := range parts[1:] {
+		replacer.WriteString(buf, ".")
+		replacer.WriteString(buf, part)
+	}
+
+	return buf.String()
 }
 
 // Flattens the key for formatting along with its labels, removes spaces

--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -1,0 +1,133 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// MetricsSummary holds a roll-up of metrics info for a given interval
+type MetricsSummary struct {
+	Timestamp string
+	Gauges    []GaugeValue
+	Points    []PointValue
+	Counters  []SampledValue
+	Samples   []SampledValue
+}
+
+type GaugeValue struct {
+	Name   string
+	Value  float32
+	Labels map[string]string
+}
+
+type PointValue struct {
+	Name   string
+	Points []float32
+}
+
+type SampledValue struct {
+	Name string
+	*AggregateSample
+	Mean   float64
+	Stddev float64
+	Labels map[string]string
+}
+
+// DisplayMetrics returns a summary of the metrics from the most recent finished interval.
+func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	i.intervalLock.Lock()
+	defer i.intervalLock.Unlock()
+
+	var interval *IntervalMetrics
+	n := len(i.intervals)
+	switch {
+	case n == 0:
+		return nil, fmt.Errorf("no metric intervals have been initialized yet")
+	case n == 1:
+		interval = i.intervals[0]
+	default:
+		interval = i.intervals[n-2]
+	}
+
+	summary := MetricsSummary{
+		Timestamp: interval.Interval.String(),
+		Gauges:    []GaugeValue{},
+		Points:    []PointValue{},
+	}
+
+	// Format and sort the output of each metric type, so it gets displayed in a
+	// deterministic order.
+	for name, points := range interval.Points {
+		summary.Points = append(summary.Points, PointValue{name, points})
+	}
+	sort.Slice(summary.Points, func(i, j int) bool {
+		return summary.Points[i].Name < summary.Points[j].Name
+	})
+
+	for name, value := range interval.Gauges {
+		key, labels := extractLabels(name)
+		summary.Gauges = append(summary.Gauges, GaugeValue{key, value, labels})
+	}
+	sort.Slice(summary.Gauges, func(i, j int) bool {
+		a := combineNameLabels(summary.Gauges[i].Name, summary.Gauges[i].Labels)
+		b := combineNameLabels(summary.Gauges[j].Name, summary.Gauges[j].Labels)
+		return a < b
+	})
+
+	summary.Counters = formatSamples(interval.Counters)
+	summary.Samples = formatSamples(interval.Samples)
+
+	return summary, nil
+}
+
+func extractLabels(key string) (string, map[string]string) {
+	labels := make(map[string]string)
+	split := strings.Split(key, ";")
+	if len(split) < 2 {
+		return key, labels
+	}
+
+	for _, raw := range split[1:] {
+		s := strings.SplitN(raw, "=", 2)
+		labels[s[0]] = s[1]
+	}
+
+	return split[0], labels
+}
+
+func formatSamples(source map[string]*AggregateSample) []SampledValue {
+	output := []SampledValue{}
+	for name, aggregate := range source {
+		key, labels := extractLabels(name)
+		output = append(output, SampledValue{
+			Name:            key,
+			AggregateSample: aggregate,
+			Mean:            aggregate.Mean(),
+			Stddev:          aggregate.Stddev(),
+			Labels:          labels,
+		})
+	}
+	sort.Slice(output, func(i, j int) bool {
+		a := combineNameLabels(output[i].Name, output[i].Labels)
+		b := combineNameLabels(output[j].Name, output[j].Labels)
+		return a < b
+	})
+
+	return output
+}
+
+func combineNameLabels(name string, labels map[string]string) string {
+	var rawLabels []string
+	for name, val := range labels {
+		rawLabels = append(rawLabels, name+val)
+	}
+	sort.Strings(rawLabels)
+
+	result := name
+	for _, label := range rawLabels {
+		result += label
+	}
+	return result
+}

--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -47,15 +47,17 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 	case n == 0:
 		return nil, fmt.Errorf("no metric intervals have been initialized yet")
 	case n == 1:
+		// Show the current interval if it's all we have
 		interval = i.intervals[0]
 	default:
+		// Show the most recent finished interval if we have one
 		interval = i.intervals[n-2]
 	}
 
 	summary := MetricsSummary{
 		Timestamp: interval.Interval.Round(time.Second).UTC().String(),
-		Gauges:    []GaugeValue{},
-		Points:    []PointValue{},
+		Gauges:    make([]GaugeValue, 0, len(interval.Gauges)),
+		Points:    make([]PointValue, 0, len(interval.Points)),
 	}
 
 	// Format and sort the output of each metric type, so it gets displayed in a
@@ -82,7 +84,7 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 }
 
 func formatSamples(source map[string]SampledValue) []SampledValue {
-	output := []SampledValue{}
+	output := make([]SampledValue, 0, len(source))
 	for hash, sample := range source {
 		output = append(output, SampledValue{
 			Name:            sample.Name,

--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"time"
 )
 
 // MetricsSummary holds a roll-up of metrics info for a given interval
@@ -52,7 +53,7 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	summary := MetricsSummary{
-		Timestamp: interval.Interval.String(),
+		Timestamp: interval.Interval.Round(time.Second).UTC().String(),
 		Gauges:    []GaugeValue{},
 		Points:    []PointValue{},
 	}

--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strings"
 )
 
 // MetricsSummary holds a roll-up of metrics info for a given interval
@@ -18,8 +17,9 @@ type MetricsSummary struct {
 
 type GaugeValue struct {
 	Name   string
+	Hash   string `json:"-"`
 	Value  float32
-	Labels map[string]string
+	Labels []Label
 }
 
 type PointValue struct {
@@ -29,19 +29,19 @@ type PointValue struct {
 
 type SampledValue struct {
 	Name string
+	Hash string `json:"-"`
 	*AggregateSample
 	Mean   float64
 	Stddev float64
-	Labels map[string]string
+	Labels []Label
 }
 
 // DisplayMetrics returns a summary of the metrics from the most recent finished interval.
 func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	i.intervalLock.Lock()
-	defer i.intervalLock.Unlock()
+	data := i.Data()
 
 	var interval *IntervalMetrics
-	n := len(i.intervals)
+	n := len(data)
 	switch {
 	case n == 0:
 		return nil, fmt.Errorf("no metric intervals have been initialized yet")
@@ -66,14 +66,12 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 		return summary.Points[i].Name < summary.Points[j].Name
 	})
 
-	for name, value := range interval.Gauges {
-		key, labels := extractLabels(name)
-		summary.Gauges = append(summary.Gauges, GaugeValue{key, value, labels})
+	for hash, value := range interval.Gauges {
+		value.Hash = hash
+		summary.Gauges = append(summary.Gauges, value)
 	}
 	sort.Slice(summary.Gauges, func(i, j int) bool {
-		a := combineNameLabels(summary.Gauges[i].Name, summary.Gauges[i].Labels)
-		b := combineNameLabels(summary.Gauges[j].Name, summary.Gauges[j].Labels)
-		return a < b
+		return summary.Gauges[i].Hash < summary.Gauges[j].Hash
 	})
 
 	summary.Counters = formatSamples(interval.Counters)
@@ -82,52 +80,21 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 	return summary, nil
 }
 
-func extractLabels(key string) (string, map[string]string) {
-	labels := make(map[string]string)
-	split := strings.Split(key, ";")
-	if len(split) < 2 {
-		return key, labels
-	}
-
-	for _, raw := range split[1:] {
-		s := strings.SplitN(raw, "=", 2)
-		labels[s[0]] = s[1]
-	}
-
-	return split[0], labels
-}
-
-func formatSamples(source map[string]*AggregateSample) []SampledValue {
+func formatSamples(source map[string]SampledValue) []SampledValue {
 	output := []SampledValue{}
-	for name, aggregate := range source {
-		key, labels := extractLabels(name)
+	for hash, sample := range source {
 		output = append(output, SampledValue{
-			Name:            key,
-			AggregateSample: aggregate,
-			Mean:            aggregate.Mean(),
-			Stddev:          aggregate.Stddev(),
-			Labels:          labels,
+			Name:            sample.Name,
+			Hash:            hash,
+			AggregateSample: sample.AggregateSample,
+			Mean:            sample.AggregateSample.Mean(),
+			Stddev:          sample.AggregateSample.Stddev(),
+			Labels:          sample.Labels,
 		})
 	}
 	sort.Slice(output, func(i, j int) bool {
-		a := combineNameLabels(output[i].Name, output[i].Labels)
-		b := combineNameLabels(output[j].Name, output[j].Labels)
-		return a < b
+		return output[i].Hash < output[j].Hash
 	})
 
 	return output
-}
-
-func combineNameLabels(name string, labels map[string]string) string {
-	var rawLabels []string
-	for name, val := range labels {
-		rawLabels = append(rawLabels, name+val)
-	}
-	sort.Strings(rawLabels)
-
-	result := name
-	for _, label := range rawLabels {
-		result += label
-	}
-	return result
 }

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -30,7 +30,7 @@ func TestDisplayMetrics(t *testing.T) {
 	}
 
 	expected := MetricsSummary{
-		Timestamp: data[0].Interval.String(),
+		Timestamp: data[0].Interval.Round(time.Second).UTC().String(),
 		Gauges: []GaugeValue{
 			{
 				Name:   "foo.bar",

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -34,13 +34,15 @@ func TestDisplayMetrics(t *testing.T) {
 		Gauges: []GaugeValue{
 			{
 				Name:   "foo.bar",
+				Hash:   "foo.bar",
 				Value:  float32(42),
-				Labels: map[string]string{},
+				Labels: []Label{},
 			},
 			{
 				Name:   "foo.bar",
+				Hash:   "foo.bar;a=b",
 				Value:  float32(23),
-				Labels: map[string]string{"a": "b"},
+				Labels: []Label{{"a", "b"}},
 			},
 		},
 		Points: []PointValue{
@@ -52,6 +54,7 @@ func TestDisplayMetrics(t *testing.T) {
 		Counters: []SampledValue{
 			{
 				Name: "foo.bar",
+				Hash: "foo.bar",
 				AggregateSample: &AggregateSample{
 					Count: 2,
 					Min:   20,
@@ -65,6 +68,7 @@ func TestDisplayMetrics(t *testing.T) {
 			},
 			{
 				Name: "foo.bar",
+				Hash: "foo.bar;a=b",
 				AggregateSample: &AggregateSample{
 					Count: 2,
 					Min:   20,
@@ -75,12 +79,13 @@ func TestDisplayMetrics(t *testing.T) {
 				},
 				Mean:   30,
 				Stddev: 14.142135623730951,
-				Labels: map[string]string{"a": "b"},
+				Labels: []Label{{"a", "b"}},
 			},
 		},
 		Samples: []SampledValue{
 			{
 				Name: "foo.bar",
+				Hash: "foo.bar",
 				AggregateSample: &AggregateSample{
 					Count: 2,
 					Min:   20,
@@ -94,6 +99,7 @@ func TestDisplayMetrics(t *testing.T) {
 			},
 			{
 				Name: "foo.bar",
+				Hash: "foo.bar;a=b",
 				AggregateSample: &AggregateSample{
 					Count: 2,
 					Min:   23,
@@ -104,7 +110,7 @@ func TestDisplayMetrics(t *testing.T) {
 				},
 				Mean:   28,
 				Stddev: 7.0710678118654755,
-				Labels: map[string]string{"a": "b"},
+				Labels: []Label{{"a", "b"}},
 			},
 		},
 	}

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -1,0 +1,127 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pascaldekloe/goe/verify"
+)
+
+func TestDisplayMetrics(t *testing.T) {
+	interval := 10 * time.Millisecond
+	inm := NewInmemSink(interval, 50*time.Millisecond)
+
+	// Add data points
+	inm.SetGauge([]string{"foo", "bar"}, 42)
+	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
+	inm.EmitKey([]string{"foo", "bar"}, 42)
+	inm.IncrCounter([]string{"foo", "bar"}, 20)
+	inm.IncrCounter([]string{"foo", "bar"}, 22)
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 20, []Label{{"a", "b"}})
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 40, []Label{{"a", "b"}})
+	inm.AddSample([]string{"foo", "bar"}, 20)
+	inm.AddSample([]string{"foo", "bar"}, 24)
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 33, []Label{{"a", "b"}})
+
+	data := inm.Data()
+	if len(data) != 1 {
+		t.Fatalf("bad: %v", data)
+	}
+
+	expected := MetricsSummary{
+		Timestamp: data[0].Interval.String(),
+		Gauges: []GaugeValue{
+			{
+				Name:   "foo.bar",
+				Value:  float32(42),
+				Labels: map[string]string{},
+			},
+			{
+				Name:   "foo.bar",
+				Value:  float32(23),
+				Labels: map[string]string{"a": "b"},
+			},
+		},
+		Points: []PointValue{
+			{
+				Name:   "foo.bar",
+				Points: []float32{42},
+			},
+		},
+		Counters: []SampledValue{
+			{
+				Name: "foo.bar",
+				AggregateSample: &AggregateSample{
+					Count: 2,
+					Min:   20,
+					Max:   22,
+					Sum:   42,
+					SumSq: 884,
+					Rate:  200,
+				},
+				Mean:   21,
+				Stddev: 1.4142135623730951,
+			},
+			{
+				Name: "foo.bar",
+				AggregateSample: &AggregateSample{
+					Count: 2,
+					Min:   20,
+					Max:   40,
+					Sum:   60,
+					SumSq: 2000,
+					Rate:  200,
+				},
+				Mean:   30,
+				Stddev: 14.142135623730951,
+				Labels: map[string]string{"a": "b"},
+			},
+		},
+		Samples: []SampledValue{
+			{
+				Name: "foo.bar",
+				AggregateSample: &AggregateSample{
+					Count: 2,
+					Min:   20,
+					Max:   24,
+					Sum:   44,
+					SumSq: 976,
+					Rate:  200,
+				},
+				Mean:   22,
+				Stddev: 2.8284271247461903,
+			},
+			{
+				Name: "foo.bar",
+				AggregateSample: &AggregateSample{
+					Count: 2,
+					Min:   23,
+					Max:   33,
+					Sum:   56,
+					SumSq: 1618,
+					Rate:  200,
+				},
+				Mean:   28,
+				Stddev: 7.0710678118654755,
+				Labels: map[string]string{"a": "b"},
+			},
+		},
+	}
+
+	raw, err := inm.DisplayMetrics(nil, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	result := raw.(MetricsSummary)
+
+	// Ignore the LastUpdated field, we don't export that anyway
+	for i, got := range result.Counters {
+		expected.Counters[i].LastUpdated = got.LastUpdated
+	}
+	for i, got := range result.Samples {
+		expected.Samples[i].LastUpdated = got.LastUpdated
+	}
+
+	verify.Values(t, "all", result, expected)
+}

--- a/inmem_signal.go
+++ b/inmem_signal.go
@@ -79,7 +79,7 @@ func (i *InmemSignal) dumpStats() {
 		intv := data[i]
 		intv.RLock()
 		for name, val := range intv.Gauges {
-			fmt.Fprintf(buf, "[%v][G] '%s': %0.3f\n", intv.Interval, name, val)
+			fmt.Fprintf(buf, "[%v][G] '%s': %0.3f\n", intv.Interval, name, val.Value)
 		}
 		for name, vals := range intv.Points {
 			for _, val := range vals {
@@ -87,10 +87,10 @@ func (i *InmemSignal) dumpStats() {
 			}
 		}
 		for name, agg := range intv.Counters {
-			fmt.Fprintf(buf, "[%v][C] '%s': %s\n", intv.Interval, name, agg)
+			fmt.Fprintf(buf, "[%v][C] '%s': %s\n", intv.Interval, name, agg.AggregateSample)
 		}
 		for name, agg := range intv.Samples {
-			fmt.Fprintf(buf, "[%v][S] '%s': %s\n", intv.Interval, name, agg)
+			fmt.Fprintf(buf, "[%v][S] '%s': %s\n", intv.Interval, name, agg.AggregateSample)
 		}
 		intv.RUnlock()
 	}

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -18,11 +18,15 @@ func TestInmemSink(t *testing.T) {
 
 	// Add data points
 	inm.SetGauge([]string{"foo", "bar"}, 42)
+	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
 	inm.EmitKey([]string{"foo", "bar"}, 42)
 	inm.IncrCounter([]string{"foo", "bar"}, 20)
 	inm.IncrCounter([]string{"foo", "bar"}, 22)
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 20, []Label{{"a", "b"}})
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 22, []Label{{"a", "b"}})
 	inm.AddSample([]string{"foo", "bar"}, 20)
 	inm.AddSample([]string{"foo", "bar"}, 22)
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
 
 	data = inm.Data()
 	if len(data) != 1 {
@@ -38,46 +42,54 @@ func TestInmemSink(t *testing.T) {
 	if intvM.Gauges["foo.bar"] != 42 {
 		t.Fatalf("bad val: %v", intvM.Gauges)
 	}
+	if intvM.Gauges["foo.bar;a=b"] != 23 {
+		t.Fatalf("bad val: %v", intvM.Gauges)
+	}
 	if intvM.Points["foo.bar"][0] != 42 {
 		t.Fatalf("bad val: %v", intvM.Points)
 	}
 
-	agg := intvM.Counters["foo.bar"]
-	if agg.Count != 2 {
-		t.Fatalf("bad val: %v", agg)
-	}
-	if agg.Rate != 200 {
-		t.Fatalf("bad val: %v", agg.Rate)
-	}
-	if agg.Sum != 42 {
-		t.Fatalf("bad val: %v", agg)
-	}
-	if agg.SumSq != 884 {
-		t.Fatalf("bad val: %v", agg)
-	}
-	if agg.Min != 20 {
-		t.Fatalf("bad val: %v", agg)
-	}
-	if agg.Max != 22 {
-		t.Fatalf("bad val: %v", agg)
-	}
-	if agg.Mean() != 21 {
-		t.Fatalf("bad val: %v", agg)
-	}
-	if agg.Stddev() != math.Sqrt(2) {
-		t.Fatalf("bad val: %v", agg)
+	for _, agg := range []*AggregateSample{intvM.Counters["foo.bar"], intvM.Counters["foo.bar;a=b"]} {
+		if agg.Count != 2 {
+			t.Fatalf("bad val: %v", agg)
+		}
+		if agg.Rate != 200 {
+			t.Fatalf("bad val: %v", agg.Rate)
+		}
+		if agg.Sum != 42 {
+			t.Fatalf("bad val: %v", agg)
+		}
+		if agg.SumSq != 884 {
+			t.Fatalf("bad val: %v", agg)
+		}
+		if agg.Min != 20 {
+			t.Fatalf("bad val: %v", agg)
+		}
+		if agg.Max != 22 {
+			t.Fatalf("bad val: %v", agg)
+		}
+		if agg.Mean() != 21 {
+			t.Fatalf("bad val: %v", agg)
+		}
+		if agg.Stddev() != math.Sqrt(2) {
+			t.Fatalf("bad val: %v", agg)
+		}
+
+		if agg.LastUpdated.IsZero() {
+			t.Fatalf("agg.LastUpdated is not set: %v", agg)
+		}
+
+		diff := time.Now().Sub(agg.LastUpdated).Seconds()
+		if diff > 1 {
+			t.Fatalf("time diff too great: %f", diff)
+		}
 	}
 
-	if agg.LastUpdated.IsZero() {
-		t.Fatalf("agg.LastUpdated is not set: %v", agg)
+	if agg := intvM.Samples["foo.bar"]; agg == nil {
+		t.Fatalf("missing sample")
 	}
 
-	diff := time.Now().Sub(agg.LastUpdated).Seconds()
-	if diff > 1 {
-		t.Fatalf("time diff too great: %f", diff)
-	}
-
-	if agg = intvM.Samples["foo.bar"]; agg == nil {
+	if agg := intvM.Samples["foo.bar;a=b"]; agg == nil {
 		t.Fatalf("missing sample")
 	}
 

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -39,17 +39,17 @@ func TestInmemSink(t *testing.T) {
 	if time.Now().Sub(intvM.Interval) > 10*time.Millisecond {
 		t.Fatalf("interval too old")
 	}
-	if intvM.Gauges["foo.bar"] != 42 {
+	if intvM.Gauges["foo.bar"].Value != 42 {
 		t.Fatalf("bad val: %v", intvM.Gauges)
 	}
-	if intvM.Gauges["foo.bar;a=b"] != 23 {
+	if intvM.Gauges["foo.bar;a=b"].Value != 23 {
 		t.Fatalf("bad val: %v", intvM.Gauges)
 	}
 	if intvM.Points["foo.bar"][0] != 42 {
 		t.Fatalf("bad val: %v", intvM.Points)
 	}
 
-	for _, agg := range []*AggregateSample{intvM.Counters["foo.bar"], intvM.Counters["foo.bar;a=b"]} {
+	for _, agg := range []SampledValue{intvM.Counters["foo.bar"], intvM.Counters["foo.bar;a=b"]} {
 		if agg.Count != 2 {
 			t.Fatalf("bad val: %v", agg)
 		}
@@ -68,10 +68,10 @@ func TestInmemSink(t *testing.T) {
 		if agg.Max != 22 {
 			t.Fatalf("bad val: %v", agg)
 		}
-		if agg.Mean() != 21 {
+		if agg.AggregateSample.Mean() != 21 {
 			t.Fatalf("bad val: %v", agg)
 		}
-		if agg.Stddev() != math.Sqrt(2) {
+		if agg.AggregateSample.Stddev() != math.Sqrt(2) {
 			t.Fatalf("bad val: %v", agg)
 		}
 
@@ -85,11 +85,11 @@ func TestInmemSink(t *testing.T) {
 		}
 	}
 
-	if agg := intvM.Samples["foo.bar"]; agg == nil {
+	if _, ok := intvM.Samples["foo.bar"]; !ok {
 		t.Fatalf("missing sample")
 	}
 
-	if agg := intvM.Samples["foo.bar;a=b"]; agg == nil {
+	if _, ok := intvM.Samples["foo.bar;a=b"]; !ok {
 		t.Fatalf("missing sample")
 	}
 

--- a/metrics.go
+++ b/metrics.go
@@ -5,7 +5,16 @@ import (
 	"time"
 )
 
+type Label struct {
+	Name  string
+	Value string
+}
+
 func (m *Metrics) SetGauge(key []string, val float32) {
+	m.SetGaugeWithLabels(key, val, nil)
+}
+
+func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	if m.HostName != "" && m.EnableHostname {
 		key = insert(0, m.HostName, key)
 	}
@@ -15,7 +24,7 @@ func (m *Metrics) SetGauge(key []string, val float32) {
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
 	}
-	m.sink.SetGauge(key, val)
+	m.sink.SetGaugeWithLabels(key, val, labels)
 }
 
 func (m *Metrics) EmitKey(key []string, val float32) {
@@ -29,26 +38,38 @@ func (m *Metrics) EmitKey(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounter(key []string, val float32) {
+	m.IncrCounterWithLabels(key, val, nil)
+}
+
+func (m *Metrics) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
 	}
-	m.sink.IncrCounter(key, val)
+	m.sink.IncrCounterWithLabels(key, val, labels)
 }
 
 func (m *Metrics) AddSample(key []string, val float32) {
+	m.AddSampleWithLabels(key, val, nil)
+}
+
+func (m *Metrics) AddSampleWithLabels(key []string, val float32, labels []Label) {
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
 	}
 	if m.ServiceName != "" {
 		key = insert(0, m.ServiceName, key)
 	}
-	m.sink.AddSample(key, val)
+	m.sink.AddSampleWithLabels(key, val, labels)
 }
 
 func (m *Metrics) MeasureSince(key []string, start time.Time) {
+	m.MeasureSinceWithLabels(key, start, nil)
+}
+
+func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)
 	}
@@ -58,7 +79,7 @@ func (m *Metrics) MeasureSince(key []string, start time.Time) {
 	now := time.Now()
 	elapsed := now.Sub(start)
 	msec := float32(elapsed.Nanoseconds()) / float32(m.TimerGranularity)
-	m.sink.AddSample(key, msec)
+	m.sink.AddSampleWithLabels(key, msec, labels)
 }
 
 // Periodically collects runtime stats to publish

--- a/metrics.go
+++ b/metrics.go
@@ -16,14 +16,22 @@ func (m *Metrics) SetGauge(key []string, val float32) {
 }
 
 func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) {
-	if m.HostName != "" && m.EnableHostname {
-		key = insert(0, m.HostName, key)
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "gauge", key)
 	}
 	if m.ServiceName != "" {
-		key = insert(0, m.ServiceName, key)
+		if m.EnableServiceLabel {
+			labels = append(labels, Label{"service", m.ServiceName})
+		} else {
+			key = insert(0, m.ServiceName, key)
+		}
 	}
 	if !m.allowMetric(key) {
 		return
@@ -49,11 +57,18 @@ func (m *Metrics) IncrCounter(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounterWithLabels(key []string, val float32, labels []Label) {
+	if m.HostName != "" && m.EnableHostnameLabel {
+		labels = append(labels, Label{"host", m.HostName})
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
 	}
 	if m.ServiceName != "" {
-		key = insert(0, m.ServiceName, key)
+		if m.EnableServiceLabel {
+			labels = append(labels, Label{"service", m.ServiceName})
+		} else {
+			key = insert(0, m.ServiceName, key)
+		}
 	}
 	if !m.allowMetric(key) {
 		return
@@ -66,11 +81,18 @@ func (m *Metrics) AddSample(key []string, val float32) {
 }
 
 func (m *Metrics) AddSampleWithLabels(key []string, val float32, labels []Label) {
+	if m.HostName != "" && m.EnableHostnameLabel {
+		labels = append(labels, Label{"host", m.HostName})
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
 	}
 	if m.ServiceName != "" {
-		key = insert(0, m.ServiceName, key)
+		if m.EnableServiceLabel {
+			labels = append(labels, Label{"service", m.ServiceName})
+		} else {
+			key = insert(0, m.ServiceName, key)
+		}
 	}
 	if !m.allowMetric(key) {
 		return
@@ -83,11 +105,18 @@ func (m *Metrics) MeasureSince(key []string, start time.Time) {
 }
 
 func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
+	if m.HostName != "" && m.EnableHostnameLabel {
+		labels = append(labels, Label{"host", m.HostName})
+	}
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)
 	}
 	if m.ServiceName != "" {
-		key = insert(0, m.ServiceName, key)
+		if m.EnableServiceLabel {
+			labels = append(labels, Label{"service", m.ServiceName})
+		} else {
+			key = insert(0, m.ServiceName, key)
+		}
 	}
 	if !m.allowMetric(key) {
 		return

--- a/metrics.go
+++ b/metrics.go
@@ -130,7 +130,7 @@ func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels [
 // Returns whether the metric should be allowed based on configured prefix filters
 func (m *Metrics) allowMetric(key []string) bool {
 	if m.filter == nil || m.filter.Len() == 0 {
-		return true
+		return m.Config.FilterDefault
 	}
 
 	_, allowed, ok := m.filter.Root().LongestPrefix([]byte(strings.Join(key, ".")))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -24,6 +24,19 @@ func TestMetrics_SetGauge(t *testing.T) {
 	}
 
 	m, met = mockMetric()
+	labels := []Label{{"a", "b"}}
+	met.SetGaugeWithLabels([]string{"key"}, float32(1), labels)
+	if m.keys[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+	if !reflect.DeepEqual(m.labels[0], labels) {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
 	met.HostName = "test"
 	met.EnableHostname = true
 	met.SetGauge([]string{"key"}, float32(1))
@@ -97,6 +110,19 @@ func TestMetrics_IncrCounter(t *testing.T) {
 	}
 
 	m, met = mockMetric()
+	labels := []Label{{"a", "b"}}
+	met.IncrCounterWithLabels([]string{"key"}, float32(1), labels)
+	if m.keys[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+	if !reflect.DeepEqual(m.labels[0], labels) {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
 	met.EnableTypePrefix = true
 	met.IncrCounter([]string{"key"}, float32(1))
 	if m.keys[0][0] != "counter" || m.keys[0][1] != "key" {
@@ -124,6 +150,19 @@ func TestMetrics_AddSample(t *testing.T) {
 		t.Fatalf("")
 	}
 	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	labels := []Label{{"a", "b"}}
+	met.AddSampleWithLabels([]string{"key"}, float32(1), labels)
+	if m.keys[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] != 1 {
+		t.Fatalf("")
+	}
+	if !reflect.DeepEqual(m.labels[0], labels) {
 		t.Fatalf("")
 	}
 
@@ -157,6 +196,20 @@ func TestMetrics_MeasureSince(t *testing.T) {
 		t.Fatalf("")
 	}
 	if m.vals[0] > 0.1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	met.TimerGranularity = time.Millisecond
+	labels := []Label{{"a", "b"}}
+	met.MeasureSinceWithLabels([]string{"key"}, n, labels)
+	if m.keys[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.vals[0] > 0.1 {
+		t.Fatalf("")
+	}
+	if !reflect.DeepEqual(m.labels[0], labels) {
 		t.Fatalf("")
 	}
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -9,7 +9,7 @@ import (
 
 func mockMetric() (*MockSink, *Metrics) {
 	m := &MockSink{}
-	met := &Metrics{sink: m}
+	met := &Metrics{Config: Config{FilterDefault: true}, sink: m}
 	return m, met
 }
 

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -2,11 +2,10 @@
 package prometheus
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
-
-	"fmt"
 
 	"github.com/armon/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"

--- a/sink.go
+++ b/sink.go
@@ -10,31 +10,41 @@ import (
 type MetricSink interface {
 	// A Gauge should retain the last value it is set to
 	SetGauge(key []string, val float32)
+	SetGaugeWithLabels(key []string, val float32, labels []Label)
 
 	// Should emit a Key/Value pair for each call
 	EmitKey(key []string, val float32)
 
 	// Counters should accumulate values
 	IncrCounter(key []string, val float32)
+	IncrCounterWithLabels(key []string, val float32, labels []Label)
 
 	// Samples are for timing information, where quantiles are used
 	AddSample(key []string, val float32)
+	AddSampleWithLabels(key []string, val float32, labels []Label)
 }
 
 // BlackholeSink is used to just blackhole messages
 type BlackholeSink struct{}
 
-func (*BlackholeSink) SetGauge(key []string, val float32)    {}
-func (*BlackholeSink) EmitKey(key []string, val float32)     {}
-func (*BlackholeSink) IncrCounter(key []string, val float32) {}
-func (*BlackholeSink) AddSample(key []string, val float32)   {}
+func (*BlackholeSink) SetGauge(key []string, val float32)                              {}
+func (*BlackholeSink) SetGaugeWithLabels(key []string, val float32, labels []Label)    {}
+func (*BlackholeSink) EmitKey(key []string, val float32)                               {}
+func (*BlackholeSink) IncrCounter(key []string, val float32)                           {}
+func (*BlackholeSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {}
+func (*BlackholeSink) AddSample(key []string, val float32)                             {}
+func (*BlackholeSink) AddSampleWithLabels(key []string, val float32, labels []Label)   {}
 
 // FanoutSink is used to sink to fanout values to multiple sinks
 type FanoutSink []MetricSink
 
 func (fh FanoutSink) SetGauge(key []string, val float32) {
+	fh.SetGaugeWithLabels(key, val, nil)
+}
+
+func (fh FanoutSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	for _, s := range fh {
-		s.SetGauge(key, val)
+		s.SetGaugeWithLabels(key, val, labels)
 	}
 }
 
@@ -45,14 +55,22 @@ func (fh FanoutSink) EmitKey(key []string, val float32) {
 }
 
 func (fh FanoutSink) IncrCounter(key []string, val float32) {
+	fh.IncrCounterWithLabels(key, val, nil)
+}
+
+func (fh FanoutSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	for _, s := range fh {
-		s.IncrCounter(key, val)
+		s.IncrCounterWithLabels(key, val, labels)
 	}
 }
 
 func (fh FanoutSink) AddSample(key []string, val float32) {
+	fh.AddSampleWithLabels(key, val, nil)
+}
+
+func (fh FanoutSink) AddSampleWithLabels(key []string, val float32, labels []Label) {
 	for _, s := range fh {
-		s.AddSample(key, val)
+		s.AddSampleWithLabels(key, val, labels)
 	}
 }
 

--- a/sink_test.go
+++ b/sink_test.go
@@ -7,25 +7,39 @@ import (
 )
 
 type MockSink struct {
-	keys [][]string
-	vals []float32
+	keys   [][]string
+	vals   []float32
+	labels [][]Label
 }
 
 func (m *MockSink) SetGauge(key []string, val float32) {
+	m.SetGaugeWithLabels(key, val, nil)
+}
+func (m *MockSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	m.keys = append(m.keys, key)
 	m.vals = append(m.vals, val)
+	m.labels = append(m.labels, labels)
 }
 func (m *MockSink) EmitKey(key []string, val float32) {
 	m.keys = append(m.keys, key)
 	m.vals = append(m.vals, val)
+	m.labels = append(m.labels, nil)
 }
 func (m *MockSink) IncrCounter(key []string, val float32) {
+	m.IncrCounterWithLabels(key, val, nil)
+}
+func (m *MockSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	m.keys = append(m.keys, key)
 	m.vals = append(m.vals, val)
+	m.labels = append(m.labels, labels)
 }
 func (m *MockSink) AddSample(key []string, val float32) {
+	m.AddSampleWithLabels(key, val, nil)
+}
+func (m *MockSink) AddSampleWithLabels(key []string, val float32, labels []Label) {
 	m.keys = append(m.keys, key)
 	m.vals = append(m.vals, val)
+	m.labels = append(m.labels, labels)
 }
 
 func TestFanoutSink_Gauge(t *testing.T) {
@@ -47,6 +61,36 @@ func TestFanoutSink_Gauge(t *testing.T) {
 		t.Fatalf("val not equal")
 	}
 	if !reflect.DeepEqual(m2.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+}
+
+func TestFanoutSink_Gauge_Labels(t *testing.T) {
+	m1 := &MockSink{}
+	m2 := &MockSink{}
+	fh := &FanoutSink{m1, m2}
+
+	k := []string{"test"}
+	v := float32(42.0)
+	l := []Label{{"a", "b"}}
+	fh.SetGaugeWithLabels(k, v, l)
+
+	if !reflect.DeepEqual(m1.keys[0], k) {
+		t.Fatalf("key not equal")
+	}
+	if !reflect.DeepEqual(m2.keys[0], k) {
+		t.Fatalf("key not equal")
+	}
+	if !reflect.DeepEqual(m1.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m2.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m1.labels[0], l) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m2.labels[0], l) {
 		t.Fatalf("val not equal")
 	}
 }
@@ -97,6 +141,36 @@ func TestFanoutSink_Counter(t *testing.T) {
 	}
 }
 
+func TestFanoutSink_Counter_Labels(t *testing.T) {
+	m1 := &MockSink{}
+	m2 := &MockSink{}
+	fh := &FanoutSink{m1, m2}
+
+	k := []string{"test"}
+	v := float32(42.0)
+	l := []Label{{"a", "b"}}
+	fh.IncrCounterWithLabels(k, v, l)
+
+	if !reflect.DeepEqual(m1.keys[0], k) {
+		t.Fatalf("key not equal")
+	}
+	if !reflect.DeepEqual(m2.keys[0], k) {
+		t.Fatalf("key not equal")
+	}
+	if !reflect.DeepEqual(m1.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m2.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m1.labels[0], l) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m2.labels[0], l) {
+		t.Fatalf("val not equal")
+	}
+}
+
 func TestFanoutSink_Sample(t *testing.T) {
 	m1 := &MockSink{}
 	m2 := &MockSink{}
@@ -116,6 +190,36 @@ func TestFanoutSink_Sample(t *testing.T) {
 		t.Fatalf("val not equal")
 	}
 	if !reflect.DeepEqual(m2.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+}
+
+func TestFanoutSink_Sample_Labels(t *testing.T) {
+	m1 := &MockSink{}
+	m2 := &MockSink{}
+	fh := &FanoutSink{m1, m2}
+
+	k := []string{"test"}
+	v := float32(42.0)
+	l := []Label{{"a", "b"}}
+	fh.AddSampleWithLabels(k, v, l)
+
+	if !reflect.DeepEqual(m1.keys[0], k) {
+		t.Fatalf("key not equal")
+	}
+	if !reflect.DeepEqual(m2.keys[0], k) {
+		t.Fatalf("key not equal")
+	}
+	if !reflect.DeepEqual(m1.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m2.vals[0], v) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m1.labels[0], l) {
+		t.Fatalf("val not equal")
+	}
+	if !reflect.DeepEqual(m2.labels[0], l) {
 		t.Fatalf("val not equal")
 	}
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -88,10 +88,10 @@ func TestFanoutSink_Gauge_Labels(t *testing.T) {
 		t.Fatalf("val not equal")
 	}
 	if !reflect.DeepEqual(m1.labels[0], l) {
-		t.Fatalf("val not equal")
+		t.Fatalf("labels not equal")
 	}
 	if !reflect.DeepEqual(m2.labels[0], l) {
-		t.Fatalf("val not equal")
+		t.Fatalf("labels not equal")
 	}
 }
 
@@ -164,10 +164,10 @@ func TestFanoutSink_Counter_Labels(t *testing.T) {
 		t.Fatalf("val not equal")
 	}
 	if !reflect.DeepEqual(m1.labels[0], l) {
-		t.Fatalf("val not equal")
+		t.Fatalf("labels not equal")
 	}
 	if !reflect.DeepEqual(m2.labels[0], l) {
-		t.Fatalf("val not equal")
+		t.Fatalf("labels not equal")
 	}
 }
 
@@ -217,10 +217,10 @@ func TestFanoutSink_Sample_Labels(t *testing.T) {
 		t.Fatalf("val not equal")
 	}
 	if !reflect.DeepEqual(m1.labels[0], l) {
-		t.Fatalf("val not equal")
+		t.Fatalf("labels not equal")
 	}
 	if !reflect.DeepEqual(m2.labels[0], l) {
-		t.Fatalf("val not equal")
+		t.Fatalf("labels not equal")
 	}
 }
 

--- a/start.go
+++ b/start.go
@@ -79,6 +79,10 @@ func SetGauge(key []string, val float32) {
 	globalMetrics.Load().(*Metrics).SetGauge(key, val)
 }
 
+func SetGaugeWithLabels(key []string, val float32, labels []Label) {
+	globalMetrics.Load().(*Metrics).SetGaugeWithLabels(key, val, labels)
+}
+
 func EmitKey(key []string, val float32) {
 	globalMetrics.Load().(*Metrics).EmitKey(key, val)
 }
@@ -87,8 +91,16 @@ func IncrCounter(key []string, val float32) {
 	globalMetrics.Load().(*Metrics).IncrCounter(key, val)
 }
 
+func IncrCounterWithLabels(key []string, val float32, labels []Label) {
+	globalMetrics.Load().(*Metrics).IncrCounterWithLabels(key, val, labels)
+}
+
 func AddSample(key []string, val float32) {
 	globalMetrics.Load().(*Metrics).AddSample(key, val)
+}
+
+func AddSampleWithLabels(key []string, val float32, labels []Label) {
+	globalMetrics.Load().(*Metrics).AddSampleWithLabels(key, val, labels)
 }
 
 func MeasureSince(key []string, start time.Time) {

--- a/start.go
+++ b/start.go
@@ -13,6 +13,8 @@ type Config struct {
 	ServiceName          string        // Prefixed with keys to seperate services
 	HostName             string        // Hostname to use. If not provided and EnableHostname, it will be os.Hostname
 	EnableHostname       bool          // Enable prefixing gauge values with hostname
+	EnableHostnameLabel  bool          // Enable adding hostname to labels
+	EnableServiceLabel   bool          // Enable adding service to labels
 	EnableRuntimeMetrics bool          // Enables profiling of runtime metrics (GC, Goroutines, Memory)
 	EnableTypePrefix     bool          // Prefixes key with a type ("counter", "gauge", "timer")
 	TimerGranularity     time.Duration // Granularity of timers.

--- a/start_test.go
+++ b/start_test.go
@@ -30,6 +30,7 @@ func TestDefaultConfig(t *testing.T) {
 		t.Fatalf("bad interval")
 	}
 }
+
 func Test_GlobalMetrics(t *testing.T) {
 	var tests = []struct {
 		desc string
@@ -52,6 +53,38 @@ func Test_GlobalMetrics(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got val %s want %s", got, want)
+			}
+		})
+	}
+}
+
+func Test_GlobalMetrics_Labels(t *testing.T) {
+	labels := []Label{{"a", "b"}}
+	var tests = []struct {
+		desc   string
+		key    []string
+		val    float32
+		fn     func([]string, float32, []Label)
+		labels []Label
+	}{
+		{"SetGaugeWithLabels", []string{"test"}, 42, SetGaugeWithLabels, labels},
+		{"IncrCounterWithLabels", []string{"test"}, 42, IncrCounterWithLabels, labels},
+		{"AddSampleWithLabels", []string{"test"}, 42, AddSampleWithLabels, labels},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s := &MockSink{}
+			globalMetrics.Store(&Metrics{sink: s})
+			tt.fn(tt.key, tt.val, tt.labels)
+			if got, want := s.keys[0], tt.key; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got key %s want %s", got, want)
+			}
+			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got val %s want %s", got, want)
+			}
+			if got, want := s.labels[0], tt.labels; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got val %s want %s", got, want)
 			}
 		})

--- a/start_test.go
+++ b/start_test.go
@@ -47,7 +47,7 @@ func Test_GlobalMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			s := &MockSink{}
-			globalMetrics.Store(&Metrics{sink: s})
+			globalMetrics.Store(&Metrics{Config: Config{FilterDefault: true}, sink: s})
 			tt.fn(tt.key, tt.val)
 			if got, want := s.keys[0], tt.key; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got key %s want %s", got, want)
@@ -76,7 +76,7 @@ func Test_GlobalMetrics_Labels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			s := &MockSink{}
-			globalMetrics.Store(&Metrics{sink: s})
+			globalMetrics.Store(&Metrics{Config: Config{FilterDefault: true}, sink: s})
 			tt.fn(tt.key, tt.val, tt.labels)
 			if got, want := s.keys[0], tt.key; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got key %s want %s", got, want)
@@ -97,6 +97,7 @@ func Test_GlobalMetrics_DefaultLabels(t *testing.T) {
 		ServiceName:         "redis",
 		EnableHostnameLabel: true,
 		EnableServiceLabel:  true,
+		FilterDefault:       true,
 	}
 	labels := []Label{
 		{"host", config.HostName},
@@ -134,7 +135,7 @@ func Test_GlobalMetrics_DefaultLabels(t *testing.T) {
 
 func Test_GlobalMetrics_MeasureSince(t *testing.T) {
 	s := &MockSink{}
-	m := &Metrics{sink: s, Config: Config{TimerGranularity: time.Millisecond}}
+	m := &Metrics{sink: s, Config: Config{TimerGranularity: time.Millisecond, FilterDefault: true}}
 	globalMetrics.Store(m)
 
 	k := []string{"test"}

--- a/statsd.go
+++ b/statsd.go
@@ -50,6 +50,11 @@ func (s *StatsdSink) SetGauge(key []string, val float32) {
 	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
 }
 
+func (s *StatsdSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
+}
+
 func (s *StatsdSink) EmitKey(key []string, val float32) {
 	flatKey := s.flattenKey(key)
 	s.pushMetric(fmt.Sprintf("%s:%f|kv\n", flatKey, val))
@@ -60,8 +65,18 @@ func (s *StatsdSink) IncrCounter(key []string, val float32) {
 	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
 }
 
+func (s *StatsdSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
+}
+
 func (s *StatsdSink) AddSample(key []string, val float32) {
 	flatKey := s.flattenKey(key)
+	s.pushMetric(fmt.Sprintf("%s:%f|ms\n", flatKey, val))
+}
+
+func (s *StatsdSink) AddSampleWithLabels(key []string, val float32, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
 	s.pushMetric(fmt.Sprintf("%s:%f|ms\n", flatKey, val))
 }
 
@@ -78,6 +93,15 @@ func (s *StatsdSink) flattenKey(parts []string) string {
 			return r
 		}
 	}, joined)
+}
+
+// Flattens the key along with labels for formatting, removes spaces
+func (s *StatsdSink) flattenKeyLabels(parts []string, labels []Label) string {
+	fullName := parts
+	for _, label := range labels {
+		fullName = append(parts, label.Value)
+	}
+	return s.flattenKey(fullName)
 }
 
 // Does a non-blocking push to the metrics queue

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -66,7 +66,7 @@ func TestStatsd_Conn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err %s", err)
 		}
-		if line != "key.other:2.000000|kv\n" {
+		if line != "gauge_labels.val.label:2.000000|g\n" {
 			t.Fatalf("bad line %s", line)
 		}
 
@@ -74,7 +74,7 @@ func TestStatsd_Conn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err %s", err)
 		}
-		if line != "counter.me:3.000000|c\n" {
+		if line != "key.other:3.000000|kv\n" {
 			t.Fatalf("bad line %s", line)
 		}
 
@@ -82,7 +82,31 @@ func TestStatsd_Conn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err %s", err)
 		}
-		if line != "sample.slow_thingy:4.000000|ms\n" {
+		if line != "counter.me:4.000000|c\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "counter_labels.me.label:5.000000|c\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "sample.slow_thingy:6.000000|ms\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "sample_labels.slow_thingy.label:7.000000|ms\n" {
 			t.Fatalf("bad line %s", line)
 		}
 
@@ -94,9 +118,12 @@ func TestStatsd_Conn(t *testing.T) {
 	}
 
 	s.SetGauge([]string{"gauge", "val"}, float32(1))
-	s.EmitKey([]string{"key", "other"}, float32(2))
-	s.IncrCounter([]string{"counter", "me"}, float32(3))
-	s.AddSample([]string{"sample", "slow thingy"}, float32(4))
+	s.SetGaugeWithLabels([]string{"gauge_labels", "val"}, float32(2), []Label{{"a", "label"}})
+	s.EmitKey([]string{"key", "other"}, float32(3))
+	s.IncrCounter([]string{"counter", "me"}, float32(4))
+	s.IncrCounterWithLabels([]string{"counter_labels", "me"}, float32(5), []Label{{"a", "label"}})
+	s.AddSample([]string{"sample", "slow thingy"}, float32(6))
+	s.AddSampleWithLabels([]string{"sample_labels", "slow thingy"}, float32(7), []Label{{"a", "label"}})
 
 	select {
 	case <-done:

--- a/statsite.go
+++ b/statsite.go
@@ -50,6 +50,11 @@ func (s *StatsiteSink) SetGauge(key []string, val float32) {
 	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
 }
 
+func (s *StatsiteSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
+}
+
 func (s *StatsiteSink) EmitKey(key []string, val float32) {
 	flatKey := s.flattenKey(key)
 	s.pushMetric(fmt.Sprintf("%s:%f|kv\n", flatKey, val))
@@ -60,8 +65,18 @@ func (s *StatsiteSink) IncrCounter(key []string, val float32) {
 	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
 }
 
+func (s *StatsiteSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
+}
+
 func (s *StatsiteSink) AddSample(key []string, val float32) {
 	flatKey := s.flattenKey(key)
+	s.pushMetric(fmt.Sprintf("%s:%f|ms\n", flatKey, val))
+}
+
+func (s *StatsiteSink) AddSampleWithLabels(key []string, val float32, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
 	s.pushMetric(fmt.Sprintf("%s:%f|ms\n", flatKey, val))
 }
 
@@ -78,6 +93,14 @@ func (s *StatsiteSink) flattenKey(parts []string) string {
 			return r
 		}
 	}, joined)
+}
+
+// Flattens the key along with labels for formatting, removes spaces
+func (s *StatsiteSink) flattenKeyLabels(parts []string, labels []Label) string {
+	for _, label := range labels {
+		parts = append(parts, label.Value)
+	}
+	return s.flattenKey(parts)
 }
 
 // Does a non-blocking push to the metrics queue

--- a/statsite_test.go
+++ b/statsite_test.go
@@ -61,7 +61,7 @@ func TestStatsite_Conn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err %s", err)
 		}
-		if line != "key.other:2.000000|kv\n" {
+		if line != "gauge_labels.val.label:2.000000|g\n" {
 			t.Fatalf("bad line %s", line)
 		}
 
@@ -69,7 +69,7 @@ func TestStatsite_Conn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err %s", err)
 		}
-		if line != "counter.me:3.000000|c\n" {
+		if line != "key.other:3.000000|kv\n" {
 			t.Fatalf("bad line %s", line)
 		}
 
@@ -77,7 +77,31 @@ func TestStatsite_Conn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err %s", err)
 		}
-		if line != "sample.slow_thingy:4.000000|ms\n" {
+		if line != "counter.me:4.000000|c\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "counter_labels.me.label:5.000000|c\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "sample.slow_thingy:6.000000|ms\n" {
+			t.Fatalf("bad line %s", line)
+		}
+
+		line, err = reader.ReadString('\n')
+		if err != nil {
+			t.Fatalf("unexpected err %s", err)
+		}
+		if line != "sample_labels.slow_thingy.label:7.000000|ms\n" {
 			t.Fatalf("bad line %s", line)
 		}
 
@@ -90,9 +114,12 @@ func TestStatsite_Conn(t *testing.T) {
 	}
 
 	s.SetGauge([]string{"gauge", "val"}, float32(1))
-	s.EmitKey([]string{"key", "other"}, float32(2))
-	s.IncrCounter([]string{"counter", "me"}, float32(3))
-	s.AddSample([]string{"sample", "slow thingy"}, float32(4))
+	s.SetGaugeWithLabels([]string{"gauge_labels", "val"}, float32(2), []Label{{"a", "label"}})
+	s.EmitKey([]string{"key", "other"}, float32(3))
+	s.IncrCounter([]string{"counter", "me"}, float32(4))
+	s.IncrCounterWithLabels([]string{"counter_labels", "me"}, float32(5), []Label{{"a", "label"}})
+	s.AddSample([]string{"sample", "slow thingy"}, float32(6))
+	s.AddSampleWithLabels([]string{"sample_labels", "slow thingy"}, float32(7), []Label{{"a", "label"}})
 
 	select {
 	case <-done:


### PR DESCRIPTION
This adds new global functions for submitting metrics with key/value labels, as well as an endpoint function for displaying metrics from the most recent finished interval. Also modifies existing sinks to handle tagged metrics where applicable.

The endpoint's output looks like this when serialized to json:
```json
{
    "Timestamp": "2017-08-02 01:06:00 -0700 PDT",
    "Gauges": [
        {
            "Name": "consul.consul.session_ttl.active",
            "Value": 0,
            "Labels": {}
        },
        {
            "Name": "consul.runtime.alloc_bytes",
            "Value": 4228152,
            "Labels": {}
        }
    ],
    "Points": [],
    "Counters": [
        {
            "Name": "consul.consul.catalog.service.query",
            "Count": 3,
            "Sum": 3,
            "Min": 1,
            "Max": 1,
            "Mean": 1,
            "Stddev": 0,
            "Labels": {
                "service": "consul"
            }
        }
    ],
    "Samples": [
        {
            "Name": "consul.serf.queue.Query",
            "Count": 20,
            "Sum": 0,
            "Min": 0,
            "Max": 0,
            "Mean": 0,
            "Stddev": 0,
            "Labels": {}
        }
    ]
}