### PR TITLE
Fix broken builds against Go 1.6 and 1.7

### DIFF
--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"fmt"
 	"net/http"
-	"sort"
 	"time"
 )
 
@@ -69,9 +68,7 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 	for name, points := range interval.Points {
 		summary.Points = append(summary.Points, PointValue{name, points})
 	}
-	sort.Slice(summary.Points, func(i, j int) bool {
-		return summary.Points[i].Name < summary.Points[j].Name
-	})
+	sortPoints(summary.Points)
 
 	for hash, value := range interval.Gauges {
 		value.Hash = hash
@@ -83,9 +80,7 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 
 		summary.Gauges = append(summary.Gauges, value)
 	}
-	sort.Slice(summary.Gauges, func(i, j int) bool {
-		return summary.Gauges[i].Hash < summary.Gauges[j].Hash
-	})
+	sortGauges(summary.Gauges)
 
 	summary.Counters = formatSamples(interval.Counters)
 	summary.Samples = formatSamples(interval.Samples)
@@ -110,9 +105,7 @@ func formatSamples(source map[string]SampledValue) []SampledValue {
 			DisplayLabels:   displayLabels,
 		})
 	}
-	sort.Slice(output, func(i, j int) bool {
-		return output[i].Hash < output[j].Hash
-	})
+	sortSampled(output)
 
 	return output
 }

--- a/inmem_endpoint_1_6.go
+++ b/inmem_endpoint_1_6.go
@@ -1,0 +1,64 @@
+// +build go1.6,!go1.8
+
+package metrics
+
+import (
+	"sort"
+)
+
+// Sort the given a PointValue slice in place using Go 1.8's sort.Slice.
+func sortPoints(points []PointValue) {
+	sort.Sort(pointValues(points))
+}
+
+type pointValues []PointValue
+
+func (points pointValues) Len() int {
+	return len(points)
+}
+
+func (points pointValues) Less(i, j int) bool {
+	return points[i].Name < points[j].Name
+}
+
+func (points pointValues) Swap(i, j int) {
+	points[i], points[j] = points[j], points[1]
+}
+
+// Sort the given a GaugeValue slice in place using Go 1.8's sort.Slice.
+func sortGauges(gauges []GaugeValue) {
+	sort.Sort(gaugeValues(gauges))
+}
+
+type gaugeValues []GaugeValue
+
+func (gauges gaugeValues) Len() int {
+	return len(gauges)
+}
+
+func (gauges gaugeValues) Less(i, j int) bool {
+	return gauges[i].Hash < gauges[j].Hash
+}
+
+func (gauges gaugeValues) Swap(i, j int) {
+	gauges[i], gauges[j] = gauges[j], gauges[1]
+}
+
+// Sort the given a SampledValue slice in place using Go 1.8's sort.Slice.
+func sortSampled(sampleds []SampledValue) {
+	sort.Sort(sampledValues(sampleds))
+}
+
+type sampledValues []SampledValue
+
+func (sampled sampledValues) Len() int {
+	return len(sampled)
+}
+
+func (sampled sampledValues) Less(i, j int) bool {
+	return sampled[i].Hash < sampled[j].Hash
+}
+
+func (sampled sampledValues) Swap(i, j int) {
+	sampled[i], sampled[j] = sampled[j], sampled[1]
+}

--- a/inmem_endpoint_1_8.go
+++ b/inmem_endpoint_1_8.go
@@ -1,0 +1,28 @@
+// +build go1.8
+
+package metrics
+
+import (
+	"sort"
+)
+
+// Sort the given PointValue slice in place using Go 1.8's sort.Slice.
+func sortPoints(points []PointValue) {
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].Name < points[j].Name
+	})
+}
+
+// Sort the given GaugeValue slice in place using Go 1.8's sort.Slice.
+func sortGauges(gauges []GaugeValue) {
+	sort.Slice(gauges, func(i, j int) bool {
+		return gauges[i].Hash < gauges[j].Hash
+	})
+}
+
+// Sort the given SampledValue slice in place using Go 1.8's sort.Slice.
+func sortSampled(sampled []SampledValue) {
+	sort.Slice(sampled, func(i, j int) bool {
+		return sampled[i].Hash < sampled[j].Hash
+	})
+}


### PR DESCRIPTION
Avoid using sort.Slice when building against Go 1.6 or 1.7, instead
using the older sort.Sort interface. Fixes #59.