### PR TITLE
Add registry for external sinks

### DIFF
--- a/circonus/circonus.go
+++ b/circonus/circonus.go
@@ -1,8 +1,12 @@
-// Circonus Metrics Sink
-
+// Circonus Metrics Sink provides an interface to forward metrics to Circonus.
+//
+// It also registers a factory that can be invoked by using
+// `metrics.NewMetricSinkFromURL` addressed by a URL with scheme `circonus://`.
+// The rest of the URL is ignored.
 package circonus
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/armon/go-metrics"
@@ -44,6 +48,13 @@ func NewCirconusSink(cc *Config) (*CirconusSink, error) {
 	return &CirconusSink{
 		metrics: metrics,
 	}, nil
+}
+
+func init() {
+	metrics.RegisterSinkURLFactory("circonus",
+		func(u *url.URL) (metrics.MetricSink, error) {
+			return NewCirconusSink(nil)
+		})
 }
 
 // Start submitting metrics to Circonus (flush every SubmitInterval)

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -1,7 +1,14 @@
+// This package implements a go-metrics sink that that can be used
+// with a dogstatsd server
+//
+// It also registers a factory that can be invoked by using
+// `metrics.NewMetricSinkFromURL` addressed by a URL like:
+//   dogstatsds://<dogstatsd-host>:<dogstatsd-port>[?hostname=<hostname-to-report>]`.
 package datadog
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -28,6 +35,13 @@ func NewDogStatsdSink(addr string, hostName string) (*DogStatsdSink, error) {
 		propagateHostname: false,
 	}
 	return sink, nil
+}
+
+func init() {
+	metrics.RegisterSinkURLFactory("dogstatsd",
+		func(u *url.URL) (metrics.MetricSink, error) {
+			return NewDogStatsdSink(u.Host, u.Query().Get("hostname"))
+		})
 }
 
 // SetTags sets common tags on the Dogstatsd Client that will be sent

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -148,3 +148,19 @@ func assertServerMatchesExpected(t *testing.T, server *net.UDPConn, buf []byte, 
 		t.Fatalf("Line %s does not match expected: %s", string(msg), expected)
 	}
 }
+
+func TestFactory(t *testing.T) {
+	sink, err := metrics.NewMetricSinkFromURL("dogstatsd://example.com:8888?hostname=foo")
+	if err != nil {
+		t.Fatalf("Factory failed: %s", err)
+	}
+	dogStatsDSink, ok := sink.(*DogStatsdSink)
+	if !ok {
+		t.Fatalf("Factory returned wrong sink type: %s", reflect.TypeOf(sink))
+	}
+	if dogStatsDSink.hostName != "foo" {
+		t.Fatalf("Factory set hostName = '%s', want 'foo'", dogStatsDSink.hostName)
+	}
+	// No real way to peak inside the statsd client to assert it got the right hostname/port...
+	// I sanity checked it at least
+}

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -1,4 +1,10 @@
 // +build go1.3
+
+// This package implements a go-metrics sink that Prometheus can scrape.
+//
+// It also registers a factory that can be invoked by using
+// `metrics.NewMetricSinkFromURL` addressed by a URL scheme of `prometheus://`.
+// The rest of the URL is ignored.
 package prometheus
 
 import (
@@ -18,6 +24,10 @@ type PrometheusSink struct {
 	gauges    map[string]prometheus.Gauge
 	summaries map[string]prometheus.Summary
 	counters  map[string]prometheus.Counter
+}
+
+func init() {
+	metrics.RegisterSinkURLFactory("prometheus", NewPrometheusSink)
 }
 
 func NewPrometheusSink() (*PrometheusSink, error) {

--- a/sink_test.go
+++ b/sink_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -253,6 +254,55 @@ func TestNewMetricSinkFromURL(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			ms, err := NewMetricSinkFromURL(tc.input)
+			if tc.expectErr != "" {
+				if !strings.Contains(err.Error(), tc.expectErr) {
+					t.Fatalf("expected err: %q to contain: %q", err, tc.expectErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected err: %s", err)
+				}
+				got := reflect.TypeOf(ms)
+				if got != tc.expect {
+					t.Fatalf("expected return type to be %v, got: %v", tc.expect, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRegisterSinkURLFactory(t *testing.T) {
+	for _, tc := range []struct {
+		desc      string
+		scheme    string
+		factory   SinkURLFactoryFunc
+		input     string
+		expect    reflect.Type
+		expectErr string
+	}{
+		{
+			desc:   "custom scheme yields a Custom Sink",
+			scheme: "test",
+			factory: func(*url.URL) (MetricSink, error) {
+				return &MockSink{}, nil
+			},
+			input:  "test://someserver:123",
+			expect: reflect.TypeOf(&MockSink{}),
+		},
+		{
+			desc:   "statsd scheme (still) yields a StatsdSink",
+			scheme: "test",
+			factory: func(*url.URL) (MetricSink, error) {
+				return &MockSink{}, nil
+			},
+			input:  "statsd://someserver:123",
+			expect: reflect.TypeOf(&StatsdSink{}),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			RegisterSinkURLFactory(tc.scheme, tc.factory)
+
 			ms, err := NewMetricSinkFromURL(tc.input)
 			if tc.expectErr != "" {
 				if !strings.Contains(err.Error(), tc.expectErr) {


### PR DESCRIPTION
Fixes #63 

Comments welcome. I added registration to existing sub-package sinks. Happy to leave that out if there is a good reason to not auto-register those. I added some basic tests for those but have not actually tested end-to-end.