### PR TITLE
Fix naming collision

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -66,7 +66,7 @@ func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels 
 			ConstLabels: prometheusLabels(labels),
 		})
 		prometheus.MustRegister(g)
-		p.gauges[key] = g
+		p.gauges[hash] = g
 	}
 	g.Set(float64(val))
 }
@@ -88,7 +88,7 @@ func (p *PrometheusSink) AddSampleWithLabels(parts []string, val float32, labels
 			ConstLabels: prometheusLabels(labels),
 		})
 		prometheus.MustRegister(g)
-		p.summaries[key] = g
+		p.summaries[hash] = g
 	}
 	g.Observe(float64(val))
 }
@@ -115,7 +115,7 @@ func (p *PrometheusSink) IncrCounterWithLabels(parts []string, val float32, labe
 			ConstLabels: prometheusLabels(labels),
 		})
 		prometheus.MustRegister(g)
-		p.counters[key] = g
+		p.counters[hash] = g
 	}
 	g.Add(float64(val))
 }


### PR DESCRIPTION
It is possible to create a naming collision with tagged metrics. Using the full key to store prevents this. The full key (named hash in the code) is already used to check for the existence of a previous key. 

Other considerations- it might be better to use a true hash function when creating the full key, rather than just string concatenation. This could be fixed up in a different PR though. 