### PR TITLE
Add factory for creating DogStatsd sinks from a prexisting datadog client

### DIFF
--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -30,6 +30,15 @@ func NewDogStatsdSink(addr string, hostName string) (*DogStatsdSink, error) {
 	return sink, nil
 }
 
+// NewDogStatsdSinkFromClient returns a DogStatsdSink that uses a pre-existing datadog client
+func NewDogStatsdSinkFromClient(client *statsd.Client, hostName string) *DogStatsdSink {
+	return &DogStatsdSink{
+		client:            client,
+		hostName:          hostName,
+		propagateHostname: false,
+	}
+}
+
 // SetTags sets common tags on the Dogstatsd Client that will be sent
 // along with all dogstatsd packets.
 // Ref: http://docs.datadoghq.com/guides/dogstatsd/#tags

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/armon/go-metrics"
 )
 
@@ -81,6 +82,20 @@ func setupTestServerAndBuffer(t *testing.T) (*net.UDPConn, []byte) {
 		t.Fatal(err)
 	}
 	return server, make([]byte, 1024)
+}
+
+func TestFromClient(t *testing.T) {
+	client := &statsd.Client{}
+	hostname := "fake-hostname"
+	sink := NewDogStatsdSinkFromClient(client, hostname)
+
+	if !reflect.DeepEqual(sink.client, client) {
+		t.Fatalf("Client assigned to sink did not match what was passed in")
+	}
+
+	if sink.hostName != hostname {
+		t.Fatalf("Sink hostname did not match what was passed in, %v != %v", sink.hostName, hostname)
+	}
 }
 
 func TestParseKey(t *testing.T) {


### PR DESCRIPTION
As of right now, the datadog metric sink does not use buffered flushes, which can cause a noticeable slowdown in emitting metrics. The DogStatsd package offers a buffered version of their client, but because the client is not exported from this sink, it's not possible to set it. This change allows you to pass in a client that you initialize.

For example, it would be nice to be able to use the [buffered client](https://godoc.org/github.com/DataDog/datadog-go/statsd#NewBuffered) like so:

```go
package foo

import (
  "github.com/DataDog/datadog-go/statsd"
  "github.com/armon/go-metrics/datadog"
)

client, err := statsd.NewBuffered("localhost:8125", 1024)
if err != nil {
  panic(err)
}

sink := datadog.NewDogStatsdSinkFromClient(client, "hostname")
```