### PR TITLE
Handle ephemeral metrics

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -13,19 +13,90 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type PrometheusSink struct {
-	mu        sync.Mutex
-	gauges    map[string]prometheus.Gauge
-	summaries map[string]prometheus.Summary
-	counters  map[string]prometheus.Counter
+var (
+	// DefaultPrometheusOpts is the default set of options used when creating a
+	// PrometheusSink.
+	DefaultPrometheusOpts = PrometheusOpts{
+		Expiration: 60 * time.Second,
+	}
+)
+
+// PrometheusOpts is used to configure the Prometheus Sink
+type PrometheusOpts struct {
+	// Expiration is the duration a metric is valid for, after which it will be
+	// untracked. If the value is zero, a metric is never expired.
+	Expiration time.Duration
 }
 
+type PrometheusSink struct {
+	mu         sync.Mutex
+	gauges     map[string]prometheus.Gauge
+	summaries  map[string]prometheus.Summary
+	counters   map[string]prometheus.Counter
+	updates    map[string]time.Time
+	expiration time.Duration
+}
+
+// NewPrometheusSink creates a new PrometheusSink using the default options.
 func NewPrometheusSink() (*PrometheusSink, error) {
-	return &PrometheusSink{
-		gauges:    make(map[string]prometheus.Gauge),
-		summaries: make(map[string]prometheus.Summary),
-		counters:  make(map[string]prometheus.Counter),
-	}, nil
+	return NewPrometheusSinkFrom(DefaultPrometheusOpts)
+}
+
+// NewPrometheusSinkFrom creates a new PrometheusSink using the passed options.
+func NewPrometheusSinkFrom(opts PrometheusOpts) (*PrometheusSink, error) {
+	sink := &PrometheusSink{
+		gauges:     make(map[string]prometheus.Gauge),
+		summaries:  make(map[string]prometheus.Summary),
+		counters:   make(map[string]prometheus.Counter),
+		updates:    make(map[string]time.Time),
+		expiration: opts.Expiration,
+	}
+
+	return sink, prometheus.Register(sink)
+}
+
+// Describe is needed to meet the Collector interface.
+func (p *PrometheusSink) Describe(c chan<- *prometheus.Desc) {
+	// We must emit some description otherwise an error is returned. This
+	// description isn't shown to the user!
+	prometheus.NewGauge(prometheus.GaugeOpts{Name: "Dummy", Help: "Dummy"}).Describe(c)
+}
+
+// Collect meet the collection interface and allows us to enforce our expiration
+// logic to clean up ephemeral metrics if their value haven't been set for a
+// duration exceeding our allowed expiration time.
+func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	for k, v := range p.gauges {
+		last := p.updates[k]
+		if !last.Add(p.expiration).After(now) {
+			delete(p.updates, k)
+			delete(p.gauges, k)
+		} else {
+			v.Collect(c)
+		}
+	}
+	for k, v := range p.summaries {
+		last := p.updates[k]
+		if !last.Add(p.expiration).After(now) {
+			delete(p.updates, k)
+			delete(p.gauges, k)
+		} else {
+			v.Collect(c)
+		}
+	}
+	for k, v := range p.counters {
+		last := p.updates[k]
+		if !last.Add(p.expiration).After(now) {
+			delete(p.updates, k)
+			delete(p.gauges, k)
+		} else {
+			v.Collect(c)
+		}
+	}
 }
 
 var forbiddenChars = regexp.MustCompile("[ .=\\-]")
@@ -65,10 +136,10 @@ func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels 
 			Help:        key,
 			ConstLabels: prometheusLabels(labels),
 		})
-		prometheus.MustRegister(g)
 		p.gauges[hash] = g
 	}
 	g.Set(float64(val))
+	p.updates[hash] = time.Now()
 }
 
 func (p *PrometheusSink) AddSample(parts []string, val float32) {
@@ -87,10 +158,10 @@ func (p *PrometheusSink) AddSampleWithLabels(parts []string, val float32, labels
 			MaxAge:      10 * time.Second,
 			ConstLabels: prometheusLabels(labels),
 		})
-		prometheus.MustRegister(g)
 		p.summaries[hash] = g
 	}
 	g.Observe(float64(val))
+	p.updates[hash] = time.Now()
 }
 
 // EmitKey is not implemented. Prometheus doesn’t offer a type for which an
@@ -114,8 +185,8 @@ func (p *PrometheusSink) IncrCounterWithLabels(parts []string, val float32, labe
 			Help:        key,
 			ConstLabels: prometheusLabels(labels),
 		})
-		prometheus.MustRegister(g)
 		p.counters[hash] = g
 	}
 	g.Add(float64(val))
+	p.updates[hash] = time.Now()
 }

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -72,7 +72,7 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 	now := time.Now()
 	for k, v := range p.gauges {
 		last := p.updates[k]
-		if !last.Add(p.expiration).After(now) {
+		if p.expiration != 0 && !last.Add(p.expiration).After(now) {
 			delete(p.updates, k)
 			delete(p.gauges, k)
 		} else {
@@ -81,7 +81,7 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 	}
 	for k, v := range p.summaries {
 		last := p.updates[k]
-		if !last.Add(p.expiration).After(now) {
+		if p.expiration != 0 && !last.Add(p.expiration).After(now) {
 			delete(p.updates, k)
 			delete(p.gauges, k)
 		} else {
@@ -90,7 +90,7 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 	}
 	for k, v := range p.counters {
 		last := p.updates[k]
-		if !last.Add(p.expiration).After(now) {
+		if p.expiration != 0 && !last.Add(p.expiration).After(now) {
 			delete(p.updates, k)
 			delete(p.gauges, k)
 		} else {


### PR DESCRIPTION
This PR changes the Sink to expire metrics after a configurable
duration. Before this change, ephemeral metrics would be tracked and
emitted forever. Not only does this emit undesirable metrics, it is a
memory leak.