### PR TITLE
Fix race inmem

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -237,29 +237,32 @@ func (i *InmemSink) Data() []*IntervalMetrics {
 
 	copy(intervals[:n-1], i.intervals[:n-1])
 	current := i.intervals[n-1]
+
+	// make its own copy for current interval
 	intervals[n-1] = &IntervalMetrics{}
 	copyCurrent := intervals[n-1]
 	current.RLock()
 	*copyCurrent = *current
 
-	copyCurrent.Gauges = make(map[string]GaugeValue)
+	copyCurrent.Gauges = make(map[string]GaugeValue, len(current.Gauges))
 	for k, v := range current.Gauges {
 		copyCurrent.Gauges[k] = v
 	}
 	// saved values will be not change, just copy its link
-	copyCurrent.Points = make(map[string][]float32)
+	copyCurrent.Points = make(map[string][]float32, len(current.Points))
 	for k, v := range current.Points {
 		copyCurrent.Points[k] = v
 	}
-	copyCurrent.Counters = make(map[string]SampledValue)
+	copyCurrent.Counters = make(map[string]SampledValue, len(current.Counters))
 	for k, v := range current.Counters {
 		copyCurrent.Counters[k] = v
 	}
-	copyCurrent.Samples = make(map[string]SampledValue)
+	copyCurrent.Samples = make(map[string]SampledValue, len(current.Samples))
 	for k, v := range current.Samples {
 		copyCurrent.Samples[k] = v
 	}
 	current.RUnlock()
+
 	return intervals
 }
 

--- a/inmem.go
+++ b/inmem.go
@@ -232,8 +232,34 @@ func (i *InmemSink) Data() []*IntervalMetrics {
 	i.intervalLock.RLock()
 	defer i.intervalLock.RUnlock()
 
-	intervals := make([]*IntervalMetrics, len(i.intervals))
-	copy(intervals, i.intervals)
+	n := len(i.intervals)
+	intervals := make([]*IntervalMetrics, n)
+
+	copy(intervals[:n-1], i.intervals[:n-1])
+	current := i.intervals[n-1]
+	intervals[n-1] = &IntervalMetrics{}
+	copyCurrent := intervals[n-1]
+	current.RLock()
+	*copyCurrent = *current
+
+	copyCurrent.Gauges = make(map[string]GaugeValue)
+	for k, v := range current.Gauges {
+		copyCurrent.Gauges[k] = v
+	}
+	// saved values will be not change, just copy its link
+	copyCurrent.Points = make(map[string][]float32)
+	for k, v := range current.Points {
+		copyCurrent.Points[k] = v
+	}
+	copyCurrent.Counters = make(map[string]SampledValue)
+	for k, v := range current.Counters {
+		copyCurrent.Counters[k] = v
+	}
+	copyCurrent.Samples = make(map[string]SampledValue)
+	for k, v := range current.Samples {
+		copyCurrent.Samples[k] = v
+	}
+	current.RUnlock()
 	return intervals
 }
 


### PR DESCRIPTION
`InmemSink.Data` return pointer to current interval (alongside with others)
`InmemSink.getExistingInterval` also return current interval.
Client can write to it while read 'current' interval from intervals returned by `InmemSink.Data()`
We need create copy for current interval.