### PR TITLE
Fix some tests

### DIFF
--- a/metrics_test.go
+++ b/metrics_test.go
@@ -286,7 +286,7 @@ func TestMetrics_EmitRuntimeStats(t *testing.T) {
 	if m.keys[6][0] != "runtime" || m.keys[6][1] != "total_gc_pause_ns" {
 		t.Fatalf("bad key %v", m.keys)
 	}
-	if m.vals[6] <= 100000 {
+	if m.vals[6] <= 50000 {
 		t.Fatalf("bad val: %v", m.vals)
 	}
 

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -1,4 +1,5 @@
 // +build go1.3
+
 package prometheus
 
 import (

--- a/start_test.go
+++ b/start_test.go
@@ -53,7 +53,7 @@ func Test_GlobalMetrics(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
-				t.Fatalf("got val %s want %s", got, want)
+				t.Fatalf("got val %f want %f", got, want)
 			}
 		})
 	}
@@ -82,7 +82,7 @@ func Test_GlobalMetrics_Labels(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
-				t.Fatalf("got val %s want %s", got, want)
+				t.Fatalf("got val %f want %f", got, want)
 			}
 			if got, want := s.labels[0], tt.labels; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got val %s want %s", got, want)
@@ -124,7 +124,7 @@ func Test_GlobalMetrics_DefaultLabels(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
-				t.Fatalf("got val %s want %s", got, want)
+				t.Fatalf("got val %f want %f", got, want)
 			}
 			if got, want := s.labels[0], tt.labels; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got val %s want %s", got, want)


### PR DESCRIPTION
Tests for `github.com/armon/go-metrics/circonus` will continue to fail following the application of this patchset.  I don't know enough about the idiosyncrasies of that particular sink to say what is expected behaviour.