### PR TITLE
datadog: Sanitize commas in keys and labels

### DIFF
--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -51,6 +51,8 @@ func (s *DogStatsdSink) flattenKey(parts []string) string {
 
 func sanitize(r rune) rune {
 	switch r {
+	case ',':
+		fallthrough
 	case ':':
 		fallthrough
 	case ' ':

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -39,6 +39,7 @@ var FlattenKeyTests = []struct {
 }{
 	{[]string{"a", "b", "c"}, "a.b.c"},
 	{[]string{"spaces must", "flatten", "to", "underscores"}, "spaces_must.flatten.to.underscores"},
+	{[]string{"commas,must", "flatten", "to", "underscores"}, "commas_must.flatten.to.underscores"},
 }
 
 var MetricSinkTests = []struct {


### PR DESCRIPTION
Commas are used to delineate labels (or [_tags_](https://docs.datadoghq.com/getting_started/tagging/) in Datadogspeak) on the wire.  A label value that contains a comma will result in truncated and spurious tags.