### PR TITLE
fix panic if the GOOS doesn't support strict IEEE

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -123,10 +123,14 @@ func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels [
 	if !m.allowMetric(key) {
 		return
 	}
-	now := time.Now()
-	elapsed := now.Sub(start)
-	msec := float32(elapsed.Nanoseconds()) / float32(m.TimerGranularity)
-	m.sink.AddSampleWithLabels(key, msec, labels)
+	if m.TimerGranularity == 0 {
+		m.sink.AddSampleWithLabels(key, math.MaxFloat32, labels)
+	} else {	
+		now := time.Now()
+		elapsed := now.Sub(start)
+		msec := float32(elapsed.Nanoseconds()) / float32(m.TimerGranularity)
+		m.sink.AddSampleWithLabels(key, msec, labels)
+	}
 }
 
 // UpdateFilter overwrites the existing filter with the given rules.


### PR DESCRIPTION
the default _TimerGranularity_ is zero, and divide zero will cause SIGFPE if the code doesn't support strict IEEE.

This will be happen in gccgo under some special platform.
       
      panic: runtime error: floating point error
      [signal SIGFPE: floating-point exception code=7 addr=4859750620 pc=4859750621]

And check the zero will improve the default performances by removing the operations about time.Now.