### PR TITLE
Fixing inconsistent behaviour for keys in metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -59,8 +59,12 @@ func (m *Metrics) IncrCounter(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounterWithLabels(key []string, val float32, labels []Label) {
-	if m.HostName != "" && m.EnableHostnameLabel {
-		labels = append(labels, Label{"host", m.HostName})
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
@@ -83,8 +87,12 @@ func (m *Metrics) AddSample(key []string, val float32) {
 }
 
 func (m *Metrics) AddSampleWithLabels(key []string, val float32, labels []Label) {
-	if m.HostName != "" && m.EnableHostnameLabel {
-		labels = append(labels, Label{"host", m.HostName})
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
@@ -107,8 +115,12 @@ func (m *Metrics) MeasureSince(key []string, start time.Time) {
 }
 
 func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
-	if m.HostName != "" && m.EnableHostnameLabel {
-		labels = append(labels, Label{"host", m.HostName})
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)


### PR DESCRIPTION
Same problem like in https://github.com/armon/go-metrics/pull/20
