### PR TITLE
Apply the same logic to all metric type for Hostname prefixing

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -61,8 +61,12 @@ func (m *Metrics) IncrCounter(key []string, val float32) {
 }
 
 func (m *Metrics) IncrCounterWithLabels(key []string, val float32, labels []Label) {
-	if m.HostName != "" && m.EnableHostnameLabel {
-		labels = append(labels, Label{"host", m.HostName})
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "counter", key)
@@ -86,8 +90,12 @@ func (m *Metrics) AddSample(key []string, val float32) {
 }
 
 func (m *Metrics) AddSampleWithLabels(key []string, val float32, labels []Label) {
-	if m.HostName != "" && m.EnableHostnameLabel {
-		labels = append(labels, Label{"host", m.HostName})
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "sample", key)
@@ -111,8 +119,12 @@ func (m *Metrics) MeasureSince(key []string, start time.Time) {
 }
 
 func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
-	if m.HostName != "" && m.EnableHostnameLabel {
-		labels = append(labels, Label{"host", m.HostName})
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
 	}
 	if m.EnableTypePrefix {
 		key = insert(0, "timer", key)

--- a/start.go
+++ b/start.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -69,6 +70,11 @@ func DefaultConfig(serviceName string) *Config {
 
 // New is used to create a new instance of Metrics
 func New(conf *Config, sink MetricSink) (*Metrics, error) {
+
+	if conf.EnableHostname && conf.EnableHostnameLabel {
+		return nil, fmt.Errorf("both EnableHostname and EnableHostnameLabel can't be true at the same time")
+	}
+
 	met := &Metrics{}
 	met.Config = *conf
 	met.sink = sink


### PR DESCRIPTION
Use EnableHostname boolean in all types of metrics instead of just counter