### PR TITLE
Add forward-slash as illegal character in prometheus

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -101,7 +101,7 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 	}
 }
 
-var forbiddenChars = regexp.MustCompile("[ .=\\-]")
+var forbiddenChars = regexp.MustCompile("[ .=\\-/]")
 
 func (p *PrometheusSink) flattenKey(parts []string, labels []metrics.Label) (string, string) {
 	key := strings.Join(parts, "_")


### PR DESCRIPTION
They are considered as an illegal character in prometheus text-format in metrics_name

Example file
```
TEST[promtheus]$ cat test.txt 
# HELP vault_audit_file/_log_request vault_audit_file/_log_request
# TYPE vault_audit_file/_log_request summary
vault_audit_file/_log_request{quantile="0.5"} NaN
vault_audit_file/_log_request{quantile="0.9"} NaN
vault_audit_file/_log_request{quantile="0.99"} NaN
vault_audit_file/_log_request_sum 1.7049709558486938
vault_audit_file/_log_request_count 1
TEST[promtheus]$ cat test.txt | ./promtool check metrics
error while linting: text format parsing error in line 1: invalid metric name in comment
TEST[promtheus]$ cat test.txt | sed 's#/#_#g' | ./promtool check metrics && echo $?
0
```