### PR TITLE
Fix T.Fatalf has arg got of wrong type

### DIFF
--- a/start_test.go
+++ b/start_test.go
@@ -53,7 +53,7 @@ func Test_GlobalMetrics(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
-				t.Fatalf("got val %s want %s", got, want)
+				t.Fatalf("got val %v want %v", got, want)
 			}
 		})
 	}
@@ -82,7 +82,7 @@ func Test_GlobalMetrics_Labels(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
-				t.Fatalf("got val %s want %s", got, want)
+				t.Fatalf("got val %v want %v", got, want)
 			}
 			if got, want := s.labels[0], tt.labels; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got val %s want %s", got, want)
@@ -124,7 +124,7 @@ func Test_GlobalMetrics_DefaultLabels(t *testing.T) {
 				t.Fatalf("got key %s want %s", got, want)
 			}
 			if got, want := s.vals[0], tt.val; !reflect.DeepEqual(got, want) {
-				t.Fatalf("got val %s want %s", got, want)
+				t.Fatalf("got val %v want %v", got, want)
 			}
 			if got, want := s.labels[0], tt.labels; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got val %s want %s", got, want)


### PR DESCRIPTION
```
+ go test -buildmode pie -compiler gc -ldflags '-extldflags '\''-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '\'''
# github.com/armon/go-metrics
./start_test.go:56: T.Fatalf format %s has arg got of wrong type float32
./start_test.go:85: T.Fatalf format %s has arg got of wrong type float32
./start_test.go:127: T.Fatalf format %s has arg got of wrong type float32
FAIL	github.com/armon/go-metrics [build failed]
```