### PR TITLE
InmemSink.DisplayMetrics: use safe intervals from Data() to avoid race condition

### DIFF
--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -52,10 +52,10 @@ func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) 
 		return nil, fmt.Errorf("no metric intervals have been initialized yet")
 	case n == 1:
 		// Show the current interval if it's all we have
-		interval = i.intervals[0]
+		interval = data[0]
 	default:
 		// Show the most recent finished interval if we have one
-		interval = i.intervals[n-2]
+		interval = data[n-2]
 	}
 
 	summary := MetricsSummary{


### PR DESCRIPTION
resolves #90 