### PR TITLE
test and fix for another race condition in DisplayMetrics

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -255,11 +255,11 @@ func (i *InmemSink) Data() []*IntervalMetrics {
 	}
 	copyCurrent.Counters = make(map[string]SampledValue, len(current.Counters))
 	for k, v := range current.Counters {
-		copyCurrent.Counters[k] = v
+		copyCurrent.Counters[k] = v.deepCopy()
 	}
 	copyCurrent.Samples = make(map[string]SampledValue, len(current.Samples))
 	for k, v := range current.Samples {
-		copyCurrent.Samples[k] = v
+		copyCurrent.Samples[k] = v.deepCopy()
 	}
 	current.RUnlock()
 

--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -41,6 +41,16 @@ type SampledValue struct {
 	DisplayLabels map[string]string `json:"Labels"`
 }
 
+// deepCopy allocates a new instance of AggregateSample
+func (source SampledValue) deepCopy() SampledValue {
+	dest := source
+	if source.AggregateSample != nil {
+		dest.AggregateSample = &AggregateSample{}
+		*dest.AggregateSample = *source.AggregateSample
+	}
+	return dest
+}
+
 // DisplayMetrics returns a summary of the metrics from the most recent finished interval.
 func (i *InmemSink) DisplayMetrics(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	data := i.Data()

--- a/inmem_endpoint.go
+++ b/inmem_endpoint.go
@@ -42,8 +42,8 @@ type SampledValue struct {
 }
 
 // deepCopy allocates a new instance of AggregateSample
-func (source SampledValue) deepCopy() SampledValue {
-	dest := source
+func (source *SampledValue) deepCopy() SampledValue {
+	dest := *source
 	if source.AggregateSample != nil {
 		dest.AggregateSample = &AggregateSample{}
 		*dest.AggregateSample = *source.AggregateSample

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -233,3 +233,43 @@ func TestDisplayMetrics_RaceIncrCounter(t *testing.T) {
 	got := <-result
 	verify.Values(t, "all", got, float32(0.0))
 }
+
+func TestDisplayMetrics_RaceMetricsSetGauge(t *testing.T) {
+	interval := 200 * time.Millisecond
+	inm := NewInmemSink(interval, 10*interval)
+	met := &Metrics{Config: Config{FilterDefault: true}, sink: inm}
+	result := make(chan float32)
+	labels := []Label{
+		{"name1", "value1"},
+		{"name2", "value2"},
+	}
+
+	go func() {
+		for {
+			time.Sleep(75 * time.Millisecond)
+			met.SetGaugeWithLabels([]string{"foo", "bar"}, float32(42), labels)
+		}
+	}()
+
+	go func() {
+		start := time.Now()
+		var summary MetricsSummary
+		// test for twenty intervals
+		for time.Now().Sub(start) < 40*interval {
+			time.Sleep(150 * time.Millisecond)
+			raw, _ := inm.DisplayMetrics(nil, nil)
+			summary = raw.(MetricsSummary)
+		}
+		// save result
+		for _, g := range summary.Gauges {
+			if g.Name == "foo.bar" {
+				result <- g.Value
+			}
+		}
+		close(result)
+	}()
+
+	got := <-result
+	verify.Values(t, "all", got, float32(42))
+}
+

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -132,7 +132,7 @@ func TestDisplayMetrics(t *testing.T) {
 	verify.Values(t, "all", result, expected)
 }
 
-func TestDisplayMetricsRace(t *testing.T) {
+func TestDisplayMetrics_RaceSetGauge(t *testing.T) {
 	interval := 200 * time.Millisecond
 	inm := NewInmemSink(interval, 10*interval)
 	result := make(chan float32)
@@ -140,7 +140,7 @@ func TestDisplayMetricsRace(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(150 * time.Millisecond)
-			inm.SetGaugeWithLabels([]string{"foo", "bar"}, float32(42), []Label{{"a", "b"}})
+			inm.SetGauge([]string{"foo", "bar"}, float32(42))
 		}
 	}()
 
@@ -164,4 +164,72 @@ func TestDisplayMetricsRace(t *testing.T) {
 
 	got := <-result
 	verify.Values(t, "all", got, float32(42))
+}
+
+func TestDisplayMetrics_RaceAddSample(t *testing.T) {
+	interval := 200 * time.Millisecond
+	inm := NewInmemSink(interval, 10*interval)
+	result := make(chan float32)
+
+	go func() {
+		for {
+			time.Sleep(75 * time.Millisecond)
+			inm.AddSample([]string{"foo", "bar"}, float32(0.0))
+		}
+	}()
+
+	go func() {
+		start := time.Now()
+		var summary MetricsSummary
+		// test for twenty intervals
+		for time.Now().Sub(start) < 20*interval {
+			time.Sleep(100 * time.Millisecond)
+			raw, _ := inm.DisplayMetrics(nil, nil)
+			summary = raw.(MetricsSummary)
+		}
+		// save result
+		for _, g := range summary.Gauges {
+			if g.Name == "foo.bar" {
+				result <- g.Value
+			}
+		}
+		close(result)
+	}()
+
+	got := <-result
+	verify.Values(t, "all", got, float32(0.0))
+}
+
+func TestDisplayMetrics_RaceIncrCounter(t *testing.T) {
+	interval := 200 * time.Millisecond
+	inm := NewInmemSink(interval, 10*interval)
+	result := make(chan float32)
+
+	go func() {
+		for {
+			time.Sleep(75 * time.Millisecond)
+			inm.IncrCounter([]string{"foo", "bar"}, float32(0.0))
+		}
+	}()
+
+	go func() {
+		start := time.Now()
+		var summary MetricsSummary
+		// test for twenty intervals
+		for time.Now().Sub(start) < 20*interval {
+			time.Sleep(30 * time.Millisecond)
+			raw, _ := inm.DisplayMetrics(nil, nil)
+			summary = raw.(MetricsSummary)
+		}
+		// save result for testing
+		for _, g := range summary.Gauges {
+			if g.Name == "foo.bar" {
+				result <- g.Value
+			}
+		}
+		close(result)
+	}()
+
+	got := <-result
+	verify.Values(t, "all", got, float32(0.0))
 }

--- a/metrics.go
+++ b/metrics.go
@@ -197,7 +197,7 @@ func (m *Metrics) filterLabels(labels []Label) []Label {
 	if labels == nil {
 		return nil
 	}
-	toReturn := labels[:0]
+	toReturn := []Label{}
 	for _, label := range labels {
 		if m.labelIsAllowed(&label) {
 			toReturn = append(toReturn, label)


### PR DESCRIPTION
there was another race condition in DisplayMetrics. `AggregateSample` wasn't deep-copied on `SampledValue` assignment, so that a lock on the parent `SampledValue` didn't protect the child `AggregateSample`. this meant that `Ingest` could write while `DisplayMetrics` was being called. 

I added to tests that document this with `-race`, then modified the copy code in `Data()` to use the new deep copy.

There is another issue in `Metrics`, where the array backing the passed `labels` slice was potentially being modified. In addition to potentially surprising users of this method, it also presents an opportunity for race conditions when a `SetGaugeWithLabels` calls rewrites the backing array while a `DisplayMetrics` call is reading it. There are two tests: the first was to verify and protect the race condition; the second was to verify that the array backing the input slice isn't mutated.