### PR TITLE
Allow initializing the datadog statsd sink from an existing client

### DIFF
--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -22,12 +22,17 @@ func NewDogStatsdSink(addr string, hostName string) (*DogStatsdSink, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewDogStatsdSinkFromClient(client, hostName), nil
+}
+
+// NewDogStatsdSinkFromClient is used to create a new DogStatsdSink with an existing datadog-statsd client
+func NewDogStatsdSinkFromClient(client *statsd.Client, hostName string) *DogStatsdSink {
 	sink := &DogStatsdSink{
 		client:            client,
 		hostName:          hostName,
 		propagateHostname: false,
 	}
-	return sink, nil
+	return sink
 }
 
 // SetTags sets common tags on the Dogstatsd Client that will be sent


### PR DESCRIPTION
The client initialization for the datadog statsd sink allows for more
complex initialization options than the ones that are exposed. For
example, you can use buffered writer for performance reasons.