### PR TITLE
Add prometheus pushserver support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,14 @@ require (
 	github.com/DataDog/datadog-go v2.2.0+incompatible
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
 	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
+	github.com/golang/protobuf v1.2.0
 	github.com/hashicorp/go-immutable-radix v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.5.3 // indirect
 	github.com/pascaldekloe/goe v0.1.0
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v0.9.2
+	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
+	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 // indirect
 )

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,0 +1,85 @@
+package prometheus
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/armon/go-metrics"
+	"github.com/prometheus/common/expfmt"
+)
+
+const (
+	TestHostname = "test_hostname"
+)
+
+func MockGetHostname() string {
+	return TestHostname
+}
+
+func fakeServer(q chan string) *httptest.Server {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(202)
+		w.Header().Set("Content-Type", "application/json")
+		defer r.Body.Close()
+		dec := expfmt.NewDecoder(r.Body, expfmt.FmtProtoDelim)
+		m := &dto.MetricFamily{}
+		dec.Decode(m)
+		expectedm := &dto.MetricFamily{
+			Name: proto.String("default_one_two"),
+			Help: proto.String("default_one_two"),
+			Type: dto.MetricType_GAUGE.Enum(),
+			Metric: []*dto.Metric{
+				&dto.Metric{
+					Label: []*dto.LabelPair{
+						&dto.LabelPair{
+							Name:  proto.String("host"),
+							Value: proto.String(MockGetHostname()),
+						},
+					},
+					Gauge: &dto.Gauge{
+						Value: proto.Float64(42),
+					},
+				},
+			},
+		}
+		if !reflect.DeepEqual(m, expectedm) {
+			msg := fmt.Sprintf("Unexpected samples extracted, got: %+v, want: %+v", m, expectedm)
+			q <- errors.New(msg).Error()
+		} else {
+			q <- "ok"
+		}
+	}
+
+	return httptest.NewServer(http.HandlerFunc(handler))
+}
+
+func TestSetGauge(t *testing.T) {
+	q := make(chan string)
+	server := fakeServer(q)
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	host := u.Hostname() + ":" + u.Port()
+	sink, err := NewPrometheusPushSink(host, time.Second, "pushtest")
+	metricsConf := metrics.DefaultConfig("default")
+	metricsConf.HostName = MockGetHostname()
+	metricsConf.EnableHostnameLabel = true
+	metrics.NewGlobal(metricsConf, sink)
+	metrics.SetGauge([]string{"one", "two"}, 42)
+	response := <-q
+	if response != "ok" {
+		t.Fatal(response)
+	}
+}


### PR DESCRIPTION
Hello

In our environment we have stringent security needs.

Prometheus can not pull events from the services.

We allow only opposite connection from out backend server to 3rd party prometheus server.

We implemented this patch to push events to Prometheus push server.

Thanks and best regards,
Yuli