### PR TITLE
Fix insert() to not modify input slice

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -22,17 +22,17 @@ func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) 
 		if m.EnableHostnameLabel {
 			labels = append(labels, Label{"host", m.HostName})
 		} else if m.EnableHostname {
-			key = insert(0, m.HostName, key)
+			key = insertAtBeginning(m.HostName, key)
 		}
 	}
 	if m.EnableTypePrefix {
-		key = insert(0, "gauge", key)
+		key = insertAtBeginning("gauge", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insert(0, m.ServiceName, key)
+			key = insertAtBeginning(m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -44,10 +44,10 @@ func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) 
 
 func (m *Metrics) EmitKey(key []string, val float32) {
 	if m.EnableTypePrefix {
-		key = insert(0, "kv", key)
+		key = insertAtBeginning("kv", key)
 	}
 	if m.ServiceName != "" {
-		key = insert(0, m.ServiceName, key)
+		key = insertAtBeginning(m.ServiceName, key)
 	}
 	allowed, _ := m.allowMetric(key, nil)
 	if !allowed {
@@ -65,13 +65,13 @@ func (m *Metrics) IncrCounterWithLabels(key []string, val float32, labels []Labe
 		labels = append(labels, Label{"host", m.HostName})
 	}
 	if m.EnableTypePrefix {
-		key = insert(0, "counter", key)
+		key = insertAtBeginning("counter", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insert(0, m.ServiceName, key)
+			key = insertAtBeginning(m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -90,13 +90,13 @@ func (m *Metrics) AddSampleWithLabels(key []string, val float32, labels []Label)
 		labels = append(labels, Label{"host", m.HostName})
 	}
 	if m.EnableTypePrefix {
-		key = insert(0, "sample", key)
+		key = insertAtBeginning("sample", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insert(0, m.ServiceName, key)
+			key = insertAtBeginning(m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -115,13 +115,13 @@ func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels [
 		labels = append(labels, Label{"host", m.HostName})
 	}
 	if m.EnableTypePrefix {
-		key = insert(0, "timer", key)
+		key = insertAtBeginning("timer", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insert(0, m.ServiceName, key)
+			key = insertAtBeginning(m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -269,10 +269,9 @@ func (m *Metrics) emitRuntimeStats() {
 	m.lastNumGC = num
 }
 
-// Inserts a string value at an index into the slice
-func insert(i int, v string, s []string) []string {
-	s = append(s, "")
-	copy(s[i+1:], s[i:])
-	s[i] = v
-	return s
+// Creates a new slice with the provided string value as the first element
+// and the provided slice values as the remaining values.
+// Ordering of the values in the provided input slice is kept in tact in the output slice.
+func insertAtBeginning(v string, s []string) []string {
+	return append([]string{v}, s...)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -273,5 +273,21 @@ func (m *Metrics) emitRuntimeStats() {
 // and the provided slice values as the remaining values.
 // Ordering of the values in the provided input slice is kept in tact in the output slice.
 func insert(i int, v string, s []string) []string {
-	return append(s[:i], append([]string{v}, s[i:]...)...)
+	// Allocate new slice to avoid modifying the input slice
+	newS := make([]string, len(s)+1)
+
+	// Copy s[0, i-1] into newS
+	for j := 0; j < i; j++ {
+		newS[j] = s[j]
+	}
+
+	// Insert provided element at index i
+	newS[i] = v
+
+	// Copy s[i, len(s)-1] into newS starting at newS[i+1]
+	for j := i; j < len(s); j++ {
+		newS[j+1] = s[j]
+	}
+
+	return newS
 }

--- a/metrics.go
+++ b/metrics.go
@@ -22,17 +22,17 @@ func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) 
 		if m.EnableHostnameLabel {
 			labels = append(labels, Label{"host", m.HostName})
 		} else if m.EnableHostname {
-			key = insertAtBeginning(m.HostName, key)
+			key = insert(0, m.HostName, key)
 		}
 	}
 	if m.EnableTypePrefix {
-		key = insertAtBeginning("gauge", key)
+		key = insert(0, "gauge", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insertAtBeginning(m.ServiceName, key)
+			key = insert(0, m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -44,10 +44,10 @@ func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) 
 
 func (m *Metrics) EmitKey(key []string, val float32) {
 	if m.EnableTypePrefix {
-		key = insertAtBeginning("kv", key)
+		key = insert(0, "kv", key)
 	}
 	if m.ServiceName != "" {
-		key = insertAtBeginning(m.ServiceName, key)
+		key = insert(0, m.ServiceName, key)
 	}
 	allowed, _ := m.allowMetric(key, nil)
 	if !allowed {
@@ -65,13 +65,13 @@ func (m *Metrics) IncrCounterWithLabels(key []string, val float32, labels []Labe
 		labels = append(labels, Label{"host", m.HostName})
 	}
 	if m.EnableTypePrefix {
-		key = insertAtBeginning("counter", key)
+		key = insert(0, "counter", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insertAtBeginning(m.ServiceName, key)
+			key = insert(0, m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -90,13 +90,13 @@ func (m *Metrics) AddSampleWithLabels(key []string, val float32, labels []Label)
 		labels = append(labels, Label{"host", m.HostName})
 	}
 	if m.EnableTypePrefix {
-		key = insertAtBeginning("sample", key)
+		key = insert(0, "sample", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insertAtBeginning(m.ServiceName, key)
+			key = insert(0, m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -115,13 +115,13 @@ func (m *Metrics) MeasureSinceWithLabels(key []string, start time.Time, labels [
 		labels = append(labels, Label{"host", m.HostName})
 	}
 	if m.EnableTypePrefix {
-		key = insertAtBeginning("timer", key)
+		key = insert(0, "timer", key)
 	}
 	if m.ServiceName != "" {
 		if m.EnableServiceLabel {
 			labels = append(labels, Label{"service", m.ServiceName})
 		} else {
-			key = insertAtBeginning(m.ServiceName, key)
+			key = insert(0, m.ServiceName, key)
 		}
 	}
 	allowed, labelsFiltered := m.allowMetric(key, labels)
@@ -272,6 +272,6 @@ func (m *Metrics) emitRuntimeStats() {
 // Creates a new slice with the provided string value as the first element
 // and the provided slice values as the remaining values.
 // Ordering of the values in the provided input slice is kept in tact in the output slice.
-func insertAtBeginning(v string, s []string) []string {
-	return append([]string{v}, s...)
+func insert(i int, v string, s []string) []string {
+	return append(s[:i], append([]string{v}, s[i:]...)...)
 }


### PR DESCRIPTION
insert() in metrics.go is currently modifying the input slice.
Since this method is only ever used to prepend a value to the beginning of a slice,
changing the implementation to a new method insertAtBeginning() that does not modify
the input slice.

Signed-off-by: Ryan Turner <turner@uber.com>

Closes #101 