### PR TITLE
Make tests work in IPv6-only environments which require port picking

### DIFF
--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -11,7 +11,7 @@ import (
 var EmptyTags []metrics.Label
 
 const (
-	DogStatsdAddr    = "127.0.0.1:7254"
+	DiscardAddr      = "localhost:9"
 	HostnameEnabled  = true
 	HostnameDisabled = false
 	TestHostname     = "test_hostname"
@@ -72,7 +72,7 @@ func mockNewDogStatsdSink(addr string, labels []metrics.Label, tagWithHostname b
 }
 
 func setupTestServerAndBuffer(t *testing.T) (*net.UDPConn, []byte) {
-	udpAddr, err := net.ResolveUDPAddr("udp", DogStatsdAddr)
+	udpAddr, err := net.ResolveUDPAddr("udp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func setupTestServerAndBuffer(t *testing.T) (*net.UDPConn, []byte) {
 
 func TestParseKey(t *testing.T) {
 	for _, tt := range ParseKeyTests {
-		dog := mockNewDogStatsdSink(DogStatsdAddr, tt.Tags, tt.PropagateHostname)
+		dog := mockNewDogStatsdSink(DiscardAddr, tt.Tags, tt.PropagateHostname)
 		key, tags := dog.parseKey(tt.KeyToParse)
 
 		if !reflect.DeepEqual(key, tt.ExpectedKey) {
@@ -99,7 +99,7 @@ func TestParseKey(t *testing.T) {
 }
 
 func TestFlattenKey(t *testing.T) {
-	dog := mockNewDogStatsdSink(DogStatsdAddr, EmptyTags, HostnameDisabled)
+	dog := mockNewDogStatsdSink(DiscardAddr, EmptyTags, HostnameDisabled)
 	for _, tt := range FlattenKeyTests {
 		if !reflect.DeepEqual(dog.flattenKey(tt.KeyToFlatten), tt.Expected) {
 			t.Fatalf("Flattening %v failed", tt.KeyToFlatten)
@@ -112,7 +112,7 @@ func TestMetricSink(t *testing.T) {
 	defer server.Close()
 
 	for _, tt := range MetricSinkTests {
-		dog := mockNewDogStatsdSink(DogStatsdAddr, tt.Tags, tt.PropagateHostname)
+		dog := mockNewDogStatsdSink(server.LocalAddr().String(), tt.Tags, tt.PropagateHostname)
 		method := reflect.ValueOf(dog).MethodByName(tt.Method)
 		method.Call([]reflect.Value{
 			reflect.ValueOf(tt.Metric),
@@ -125,7 +125,7 @@ func TestTaggableMetrics(t *testing.T) {
 	server, buf := setupTestServerAndBuffer(t)
 	defer server.Close()
 
-	dog := mockNewDogStatsdSink(DogStatsdAddr, EmptyTags, HostnameDisabled)
+	dog := mockNewDogStatsdSink(server.LocalAddr().String(), EmptyTags, HostnameDisabled)
 
 	dog.AddSampleWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4.000000|ms|#tagkey:tagvalue")
@@ -136,7 +136,7 @@ func TestTaggableMetrics(t *testing.T) {
 	dog.IncrCounterWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4|c|#tagkey:tagvalue")
 
-	dog = mockNewDogStatsdSink(DogStatsdAddr, []metrics.Label{{Name: "global"}}, HostnameEnabled) // with hostname, global tags
+	dog = mockNewDogStatsdSink(server.LocalAddr().String(), []metrics.Label{{Name: "global"}}, HostnameEnabled) // with hostname, global tags
 	dog.IncrCounterWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4|c|#global,tagkey:tagvalue,host:test_hostname")
 }

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -71,7 +72,7 @@ func TestSetGauge(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	host := u.Hostname() + ":" + u.Port()
+	host := net.JoinHostPort(u.Hostname(), u.Port())
 	sink, err := NewPrometheusPushSink(host, time.Second, "pushtest")
 	metricsConf := metrics.DefaultConfig("default")
 	metricsConf.HostName = MockGetHostname()

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -38,14 +38,18 @@ func TestStatsd_PushFullQueue(t *testing.T) {
 }
 
 func TestStatsd_Conn(t *testing.T) {
-	addr := "127.0.0.1:7524"
+	udpAddr, err := net.ResolveUDPAddr("udp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		panic(err)
+	}
+	defer list.Close()
+	addr := list.LocalAddr().String()
 	done := make(chan bool)
 	go func() {
-		list, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 7524})
-		if err != nil {
-			panic(err)
-		}
-		defer list.Close()
 		buf := make([]byte, 1500)
 		n, err := list.Read(buf)
 		if err != nil {

--- a/statsite_test.go
+++ b/statsite_test.go
@@ -37,9 +37,11 @@ func TestStatsite_PushFullQueue(t *testing.T) {
 }
 
 func TestStatsite_Conn(t *testing.T) {
-	addr := "localhost:7523"
-
-	ln, _ := net.Listen("tcp", addr)
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
 
 	done := make(chan bool)
 	go func() {


### PR DESCRIPTION
Our CI environment intentionally does not offer IPv4 and does not
guarantee that all port numbers are available.
To make the tests work, I:

* Replaced the IPv4 address 127.0.0.1 with the DNS name localhost,
  which resolves to either address family depending on availability.

* Replaced string concatenation of addresses and ports with using
  net.JoinHostPort(), which also works for IPv6 addresses,
  such as the ::1 address that httptest will use in IPv6-only envs.

* Replaced all port numbers with port 0, which will make the OS
  pick an available port automatically (in listen addresses).
  This also allows for running multiple instances of the tests.