### PR TITLE
Add CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+
+orbs:
+  go: gotest/tools@0.0.13
+
+workflows:
+  ci:
+    jobs:
+    - go/test:
+        name: test-golang-1.13
+        executor:
+          name: go/golang
+          tag:  1.13-alpine
+    - go/test:
+        name: test-golang-1.14
+        executor:
+          name: go/golang
+          tag:  1.14-alpine
+    - go/test:
+        name: test-golang-1.15
+        executor:
+          name: go/golang
+          tag:  1.15-alpine

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -49,15 +49,15 @@ var MetricSinkTests = []struct {
 	PropagateHostname bool
 	Expected          string
 }{
-	{"SetGauge", []string{"foo", "bar"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar:42.000000|g"},
-	{"SetGauge", []string{"foo", "bar", "baz"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar.baz:42.000000|g"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar:42|g"},
+	{"SetGauge", []string{"foo", "bar", "baz"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar.baz:42|g"},
 	{"AddSample", []string{"sample", "thing"}, float32(4), EmptyTags, HostnameDisabled, "sample.thing:4.000000|ms"},
 	{"IncrCounter", []string{"count", "me"}, float32(3), EmptyTags, HostnameDisabled, "count.me:3|c"},
 
-	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", ""}}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag"},
-	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my tag", "my_value"}}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag:my_value"},
-	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameDisabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value"},
-	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameEnabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
+	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", ""}}, HostnameDisabled, "foo.baz:42|g|#my_tag"},
+	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my tag", "my_value"}}, HostnameDisabled, "foo.baz:42|g|#my_tag:my_value"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameDisabled, "foo.bar:42|g|#my_tag:my_value,other_tag:other_value"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameEnabled, "foo.bar:42|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
 }
 
 func mockNewDogStatsdSink(addr string, labels []metrics.Label, tagWithHostname bool) *DogStatsdSink {
@@ -112,12 +112,14 @@ func TestMetricSink(t *testing.T) {
 	defer server.Close()
 
 	for _, tt := range MetricSinkTests {
-		dog := mockNewDogStatsdSink(DogStatsdAddr, tt.Tags, tt.PropagateHostname)
-		method := reflect.ValueOf(dog).MethodByName(tt.Method)
-		method.Call([]reflect.Value{
-			reflect.ValueOf(tt.Metric),
-			reflect.ValueOf(tt.Value)})
-		assertServerMatchesExpected(t, server, buf, tt.Expected)
+		t.Run(tt.Method, func(t *testing.T) {
+			dog := mockNewDogStatsdSink(DogStatsdAddr, tt.Tags, tt.PropagateHostname)
+			method := reflect.ValueOf(dog).MethodByName(tt.Method)
+			method.Call([]reflect.Value{
+				reflect.ValueOf(tt.Metric),
+				reflect.ValueOf(tt.Value)})
+			assertServerMatchesExpected(t, server, buf, tt.Expected)
+		})
 	}
 }
 
@@ -131,7 +133,7 @@ func TestTaggableMetrics(t *testing.T) {
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4.000000|ms|#tagkey:tagvalue")
 
 	dog.SetGaugeWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
-	assertServerMatchesExpected(t, server, buf, "sample.thing:4.000000|g|#tagkey:tagvalue")
+	assertServerMatchesExpected(t, server, buf, "sample.thing:4|g|#tagkey:tagvalue")
 
 	dog.IncrCounterWithLabels([]string{"sample", "thing"}, float32(4), []metrics.Label{{"tagkey", "tagvalue"}})
 	assertServerMatchesExpected(t, server, buf, "sample.thing:4|c|#tagkey:tagvalue")
@@ -142,6 +144,7 @@ func TestTaggableMetrics(t *testing.T) {
 }
 
 func assertServerMatchesExpected(t *testing.T, server *net.UDPConn, buf []byte, expected string) {
+	t.Helper()
 	n, _ := server.Read(buf)
 	msg := buf[:n]
 	if string(msg) != expected {

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"testing"
 	"errors"
 	"fmt"
 	"log"
@@ -16,8 +15,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/armon/go-metrics"
-	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
 )
 
 const (
@@ -52,7 +51,8 @@ func TestNewPrometheusSink(t *testing.T) {
 	ok := prometheus.Unregister(sink)
 	if !ok {
 		t.Fatalf("Unregister(sink) = false, want true")
-)
+	}
+}
 
 func MockGetHostname() string {
 	return TestHostname


### PR DESCRIPTION
Builds on #114 and #115

This PR adds a CircleCI config for running tests against the last 3 major versions of Go.

You can see a run against my branch here: https://app.circleci.com/pipelines/github/dnephin/go-metrics

The only thing that is missing is to add the project to CircleCI here: https://app.circleci.com/projects/