### PR TITLE
Remove unused interface methods

### DIFF
--- a/circonus/circonus.go
+++ b/circonus/circonus.go
@@ -56,12 +56,6 @@ func (s *CirconusSink) Flush() {
 	s.metrics.Flush()
 }
 
-// SetGauge sets value for a gauge metric
-func (s *CirconusSink) SetGauge(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.metrics.SetGauge(flatKey, int64(val))
-}
-
 // SetGaugeWithLabels sets value for a gauge metric with the given labels
 func (s *CirconusSink) SetGaugeWithLabels(key []string, val float32, labels []metrics.Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
@@ -73,22 +67,10 @@ func (s *CirconusSink) EmitKey(key []string, val float32) {
 	// NOP
 }
 
-// IncrCounter increments a counter metric
-func (s *CirconusSink) IncrCounter(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.metrics.IncrementByValue(flatKey, uint64(val))
-}
-
 // IncrCounterWithLabels increments a counter metric with the given labels
 func (s *CirconusSink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.metrics.IncrementByValue(flatKey, uint64(val))
-}
-
-// AddSample adds a sample to a histogram metric
-func (s *CirconusSink) AddSample(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.metrics.RecordValue(flatKey, float64(val))
 }
 
 // AddSampleWithLabels adds a sample to a histogram metric with the given labels

--- a/circonus/circonus_test.go
+++ b/circonus/circonus_test.go
@@ -84,7 +84,7 @@ func TestSetGauge(t *testing.T) {
 	}
 
 	go func() {
-		cs.SetGauge([]string{"foo", "bar"}, 1)
+		cs.SetGaugeWithLabels([]string{"foo", "bar"}, 1, nil)
 		cs.Flush()
 	}()
 
@@ -112,7 +112,7 @@ func TestIncrCounter(t *testing.T) {
 	}
 
 	go func() {
-		cs.IncrCounter([]string{"foo", "bar"}, 1)
+		cs.IncrCounterWithLabels([]string{"foo", "bar"}, 1, nil)
 		cs.Flush()
 	}()
 
@@ -140,7 +140,7 @@ func TestAddSample(t *testing.T) {
 	}
 
 	go func() {
-		cs.AddSample([]string{"foo", "bar"}, 1)
+		cs.AddSampleWithLabels([]string{"foo", "bar"}, 1, nil)
 		cs.Flush()
 	}()
 

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -83,21 +83,9 @@ func (s *DogStatsdSink) parseKey(key []string) ([]string, []metrics.Label) {
 
 // Implementation of methods in the MetricSink interface
 
-func (s *DogStatsdSink) SetGauge(key []string, val float32) {
-	s.SetGaugeWithLabels(key, val, nil)
-}
-
-func (s *DogStatsdSink) IncrCounter(key []string, val float32) {
-	s.IncrCounterWithLabels(key, val, nil)
-}
-
 // EmitKey is not implemented since DogStatsd does not provide a metric type that holds an
 // arbitrary number of values
 func (s *DogStatsdSink) EmitKey(key []string, val float32) {
-}
-
-func (s *DogStatsdSink) AddSample(key []string, val float32) {
-	s.AddSampleWithLabels(key, val, nil)
 }
 
 // The following ...WithLabels methods correspond to Datadog's Tag extension to Statsd.

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -49,15 +49,15 @@ var MetricSinkTests = []struct {
 	PropagateHostname bool
 	Expected          string
 }{
-	{"SetGauge", []string{"foo", "bar"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar:42|g"},
-	{"SetGauge", []string{"foo", "bar", "baz"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar.baz:42|g"},
-	{"AddSample", []string{"sample", "thing"}, float32(4), EmptyTags, HostnameDisabled, "sample.thing:4.000000|ms"},
-	{"IncrCounter", []string{"count", "me"}, float32(3), EmptyTags, HostnameDisabled, "count.me:3|c"},
+	{"SetGaugeWithLabels", []string{"foo", "bar"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar:42|g"},
+	{"SetGaugeWithLabels", []string{"foo", "bar", "baz"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar.baz:42|g"},
+	{"AddSampleWithLabels", []string{"sample", "thing"}, float32(4), EmptyTags, HostnameDisabled, "sample.thing:4.000000|ms"},
+	{"IncrCounterWithLabels", []string{"count", "me"}, float32(3), EmptyTags, HostnameDisabled, "count.me:3|c"},
 
-	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", ""}}, HostnameDisabled, "foo.baz:42|g|#my_tag"},
-	{"SetGauge", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my tag", "my_value"}}, HostnameDisabled, "foo.baz:42|g|#my_tag:my_value"},
-	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameDisabled, "foo.bar:42|g|#my_tag:my_value,other_tag:other_value"},
-	{"SetGauge", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameEnabled, "foo.bar:42|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
+	{"SetGaugeWithLabels", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my_tag", ""}}, HostnameDisabled, "foo.baz:42|g|#my_tag"},
+	{"SetGaugeWithLabels", []string{"foo", "baz"}, float32(42), []metrics.Label{{"my tag", "my_value"}}, HostnameDisabled, "foo.baz:42|g|#my_tag:my_value"},
+	{"SetGaugeWithLabels", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameDisabled, "foo.bar:42|g|#my_tag:my_value,other_tag:other_value"},
+	{"SetGaugeWithLabels", []string{"foo", "bar"}, float32(42), []metrics.Label{{"my_tag", "my_value"}, {"other_tag", "other_value"}}, HostnameEnabled, "foo.bar:42|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
 }
 
 func mockNewDogStatsdSink(addr string, labels []metrics.Label, tagWithHostname bool) *DogStatsdSink {
@@ -117,7 +117,8 @@ func TestMetricSink(t *testing.T) {
 			method := reflect.ValueOf(dog).MethodByName(tt.Method)
 			method.Call([]reflect.Value{
 				reflect.ValueOf(tt.Metric),
-				reflect.ValueOf(tt.Value)})
+				reflect.ValueOf(tt.Value),
+				reflect.ValueOf([]metrics.Label{})})
 			assertServerMatchesExpected(t, server, buf, tt.Expected)
 		})
 	}

--- a/inmem.go
+++ b/inmem.go
@@ -156,10 +156,6 @@ func NewInmemSink(interval, retain time.Duration) *InmemSink {
 	return i
 }
 
-func (i *InmemSink) SetGauge(key []string, val float32) {
-	i.SetGaugeWithLabels(key, val, nil)
-}
-
 func (i *InmemSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	k, name := i.flattenKeyLabels(key, labels)
 	intv := i.getInterval()
@@ -179,10 +175,6 @@ func (i *InmemSink) EmitKey(key []string, val float32) {
 	intv.Points[k] = append(vals, val)
 }
 
-func (i *InmemSink) IncrCounter(key []string, val float32) {
-	i.IncrCounterWithLabels(key, val, nil)
-}
-
 func (i *InmemSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	k, name := i.flattenKeyLabels(key, labels)
 	intv := i.getInterval()
@@ -200,10 +192,6 @@ func (i *InmemSink) IncrCounterWithLabels(key []string, val float32, labels []La
 		intv.Counters[k] = agg
 	}
 	agg.Ingest(float64(val), i.rateDenom)
-}
-
-func (i *InmemSink) AddSample(key []string, val float32) {
-	i.AddSampleWithLabels(key, val, nil)
 }
 
 func (i *InmemSink) AddSampleWithLabels(key []string, val float32, labels []Label) {

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -12,15 +12,15 @@ func TestDisplayMetrics(t *testing.T) {
 	inm := NewInmemSink(interval, 50*time.Millisecond)
 
 	// Add data points
-	inm.SetGauge([]string{"foo", "bar"}, 42)
+	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 42, nil)
 	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
 	inm.EmitKey([]string{"foo", "bar"}, 42)
-	inm.IncrCounter([]string{"foo", "bar"}, 20)
-	inm.IncrCounter([]string{"foo", "bar"}, 22)
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 20, nil)
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 22, nil)
 	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 20, []Label{{"a", "b"}})
 	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 40, []Label{{"a", "b"}})
-	inm.AddSample([]string{"foo", "bar"}, 20)
-	inm.AddSample([]string{"foo", "bar"}, 24)
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 20, nil)
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 24, nil)
 	inm.AddSampleWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
 	inm.AddSampleWithLabels([]string{"foo", "bar"}, 33, []Label{{"a", "b"}})
 
@@ -140,7 +140,7 @@ func TestDisplayMetrics_RaceSetGauge(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(150 * time.Millisecond)
-			inm.SetGauge([]string{"foo", "bar"}, float32(42))
+			inm.SetGaugeWithLabels([]string{"foo", "bar"}, float32(42), nil)
 		}
 	}()
 
@@ -174,7 +174,7 @@ func TestDisplayMetrics_RaceAddSample(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(75 * time.Millisecond)
-			inm.AddSample([]string{"foo", "bar"}, float32(0.0))
+			inm.AddSampleWithLabels([]string{"foo", "bar"}, float32(0.0), nil)
 		}
 	}()
 
@@ -208,7 +208,7 @@ func TestDisplayMetrics_RaceIncrCounter(t *testing.T) {
 	go func() {
 		for {
 			time.Sleep(75 * time.Millisecond)
-			inm.IncrCounter([]string{"foo", "bar"}, float32(0.0))
+			inm.IncrCounterWithLabels([]string{"foo", "bar"}, float32(0.0), nil)
 		}
 	}()
 
@@ -272,4 +272,3 @@ func TestDisplayMetrics_RaceMetricsSetGauge(t *testing.T) {
 	got := <-result
 	verify.Values(t, "all", got, float32(42))
 }
-

--- a/inmem_signal_test.go
+++ b/inmem_signal_test.go
@@ -16,10 +16,10 @@ func TestInmemSignal(t *testing.T) {
 	sig := NewInmemSignal(inm, syscall.SIGUSR1, buf)
 	defer sig.Stop()
 
-	inm.SetGauge([]string{"foo"}, 42)
+	inm.SetGaugeWithLabels([]string{"foo"}, 42, nil)
 	inm.EmitKey([]string{"bar"}, 42)
-	inm.IncrCounter([]string{"baz"}, 42)
-	inm.AddSample([]string{"wow"}, 42)
+	inm.IncrCounterWithLabels([]string{"baz"}, 42, nil)
+	inm.AddSampleWithLabels([]string{"wow"}, 42, nil)
 	inm.SetGaugeWithLabels([]string{"asdf"}, 42, []Label{{"a", "b"}})
 	inm.IncrCounterWithLabels([]string{"qwer"}, 42, []Label{{"a", "b"}})
 	inm.AddSampleWithLabels([]string{"zxcv"}, 42, []Label{{"a", "b"}})

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -17,15 +17,15 @@ func TestInmemSink(t *testing.T) {
 	}
 
 	// Add data points
-	inm.SetGauge([]string{"foo", "bar"}, 42)
+	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 42, nil)
 	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
 	inm.EmitKey([]string{"foo", "bar"}, 42)
-	inm.IncrCounter([]string{"foo", "bar"}, 20)
-	inm.IncrCounter([]string{"foo", "bar"}, 22)
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 20, nil)
+	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 22, nil)
 	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 20, []Label{{"a", "b"}})
 	inm.IncrCounterWithLabels([]string{"foo", "bar"}, 22, []Label{{"a", "b"}})
-	inm.AddSample([]string{"foo", "bar"}, 20)
-	inm.AddSample([]string{"foo", "bar"}, 22)
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 20, nil)
+	inm.AddSampleWithLabels([]string{"foo", "bar"}, 22, nil)
 	inm.AddSampleWithLabels([]string{"foo", "bar"}, 23, []Label{{"a", "b"}})
 
 	data = inm.Data()
@@ -97,7 +97,7 @@ func TestInmemSink(t *testing.T) {
 
 	for i := 1; i < 10; i++ {
 		time.Sleep(10 * time.Millisecond)
-		inm.SetGauge([]string{"foo", "bar"}, 42)
+		inm.SetGaugeWithLabels([]string{"foo", "bar"}, 42, nil)
 		data = inm.Data()
 		if len(data) != min(i+1, 5) {
 			t.Fatalf("bad: %v", data)
@@ -106,7 +106,7 @@ func TestInmemSink(t *testing.T) {
 
 	// Should not exceed 5 intervals!
 	time.Sleep(10 * time.Millisecond)
-	inm.SetGauge([]string{"foo", "bar"}, 42)
+	inm.SetGaugeWithLabels([]string{"foo", "bar"}, 42, nil)
 	data = inm.Data()
 	if len(data) != 5 {
 		t.Fatalf("bad: %v", data)

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -146,10 +146,6 @@ func prometheusLabels(labels []metrics.Label) prometheus.Labels {
 	return l
 }
 
-func (p *PrometheusSink) SetGauge(parts []string, val float32) {
-	p.SetGaugeWithLabels(parts, val, nil)
-}
-
 func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels []metrics.Label) {
 	key, hash := p.flattenKey(parts, labels)
 	pg, ok := p.gauges.Load(hash)
@@ -177,10 +173,6 @@ func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels 
 		}
 		p.gauges.Store(hash, pg)
 	}
-}
-
-func (p *PrometheusSink) AddSample(parts []string, val float32) {
-	p.AddSampleWithLabels(parts, val, nil)
 }
 
 func (p *PrometheusSink) AddSampleWithLabels(parts []string, val float32, labels []metrics.Label) {
@@ -212,10 +204,6 @@ func (p *PrometheusSink) AddSampleWithLabels(parts []string, val float32, labels
 // arbitrary number of values is retained, as Prometheus works with a pull
 // model, rather than a push model.
 func (p *PrometheusSink) EmitKey(key []string, val float32) {
-}
-
-func (p *PrometheusSink) IncrCounter(parts []string, val float32) {
-	p.IncrCounterWithLabels(parts, val, nil)
 }
 
 func (p *PrometheusSink) IncrCounterWithLabels(parts []string, val float32, labels []metrics.Label) {

--- a/sink.go
+++ b/sink.go
@@ -9,38 +9,28 @@ import (
 // to an external system
 type MetricSink interface {
 	// A Gauge should retain the last value it is set to
-	SetGauge(key []string, val float32)
 	SetGaugeWithLabels(key []string, val float32, labels []Label)
 
 	// Should emit a Key/Value pair for each call
 	EmitKey(key []string, val float32)
 
 	// Counters should accumulate values
-	IncrCounter(key []string, val float32)
 	IncrCounterWithLabels(key []string, val float32, labels []Label)
 
 	// Samples are for timing information, where quantiles are used
-	AddSample(key []string, val float32)
 	AddSampleWithLabels(key []string, val float32, labels []Label)
 }
 
 // BlackholeSink is used to just blackhole messages
 type BlackholeSink struct{}
 
-func (*BlackholeSink) SetGauge(key []string, val float32)                              {}
 func (*BlackholeSink) SetGaugeWithLabels(key []string, val float32, labels []Label)    {}
 func (*BlackholeSink) EmitKey(key []string, val float32)                               {}
-func (*BlackholeSink) IncrCounter(key []string, val float32)                           {}
 func (*BlackholeSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {}
-func (*BlackholeSink) AddSample(key []string, val float32)                             {}
 func (*BlackholeSink) AddSampleWithLabels(key []string, val float32, labels []Label)   {}
 
 // FanoutSink is used to sink to fanout values to multiple sinks
 type FanoutSink []MetricSink
-
-func (fh FanoutSink) SetGauge(key []string, val float32) {
-	fh.SetGaugeWithLabels(key, val, nil)
-}
 
 func (fh FanoutSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	for _, s := range fh {
@@ -54,18 +44,10 @@ func (fh FanoutSink) EmitKey(key []string, val float32) {
 	}
 }
 
-func (fh FanoutSink) IncrCounter(key []string, val float32) {
-	fh.IncrCounterWithLabels(key, val, nil)
-}
-
 func (fh FanoutSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	for _, s := range fh {
 		s.IncrCounterWithLabels(key, val, labels)
 	}
-}
-
-func (fh FanoutSink) AddSample(key []string, val float32) {
-	fh.AddSampleWithLabels(key, val, nil)
 }
 
 func (fh FanoutSink) AddSampleWithLabels(key []string, val float32, labels []Label) {

--- a/sink_test.go
+++ b/sink_test.go
@@ -22,9 +22,6 @@ func (m *MockSink) getKeys() [][]string {
 	return m.keys
 }
 
-func (m *MockSink) SetGauge(key []string, val float32) {
-	m.SetGaugeWithLabels(key, val, nil)
-}
 func (m *MockSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -41,9 +38,6 @@ func (m *MockSink) EmitKey(key []string, val float32) {
 	m.vals = append(m.vals, val)
 	m.labels = append(m.labels, nil)
 }
-func (m *MockSink) IncrCounter(key []string, val float32) {
-	m.IncrCounterWithLabels(key, val, nil)
-}
 func (m *MockSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -52,9 +46,6 @@ func (m *MockSink) IncrCounterWithLabels(key []string, val float32, labels []Lab
 	m.vals = append(m.vals, val)
 	m.labels = append(m.labels, labels)
 }
-func (m *MockSink) AddSample(key []string, val float32) {
-	m.AddSampleWithLabels(key, val, nil)
-}
 func (m *MockSink) AddSampleWithLabels(key []string, val float32, labels []Label) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -62,29 +53,6 @@ func (m *MockSink) AddSampleWithLabels(key []string, val float32, labels []Label
 	m.keys = append(m.keys, key)
 	m.vals = append(m.vals, val)
 	m.labels = append(m.labels, labels)
-}
-
-func TestFanoutSink_Gauge(t *testing.T) {
-	m1 := &MockSink{}
-	m2 := &MockSink{}
-	fh := &FanoutSink{m1, m2}
-
-	k := []string{"test"}
-	v := float32(42.0)
-	fh.SetGauge(k, v)
-
-	if !reflect.DeepEqual(m1.keys[0], k) {
-		t.Fatalf("key not equal")
-	}
-	if !reflect.DeepEqual(m2.keys[0], k) {
-		t.Fatalf("key not equal")
-	}
-	if !reflect.DeepEqual(m1.vals[0], v) {
-		t.Fatalf("val not equal")
-	}
-	if !reflect.DeepEqual(m2.vals[0], v) {
-		t.Fatalf("val not equal")
-	}
 }
 
 func TestFanoutSink_Gauge_Labels(t *testing.T) {
@@ -140,29 +108,6 @@ func TestFanoutSink_Key(t *testing.T) {
 	}
 }
 
-func TestFanoutSink_Counter(t *testing.T) {
-	m1 := &MockSink{}
-	m2 := &MockSink{}
-	fh := &FanoutSink{m1, m2}
-
-	k := []string{"test"}
-	v := float32(42.0)
-	fh.IncrCounter(k, v)
-
-	if !reflect.DeepEqual(m1.keys[0], k) {
-		t.Fatalf("key not equal")
-	}
-	if !reflect.DeepEqual(m2.keys[0], k) {
-		t.Fatalf("key not equal")
-	}
-	if !reflect.DeepEqual(m1.vals[0], v) {
-		t.Fatalf("val not equal")
-	}
-	if !reflect.DeepEqual(m2.vals[0], v) {
-		t.Fatalf("val not equal")
-	}
-}
-
 func TestFanoutSink_Counter_Labels(t *testing.T) {
 	m1 := &MockSink{}
 	m2 := &MockSink{}
@@ -190,29 +135,6 @@ func TestFanoutSink_Counter_Labels(t *testing.T) {
 	}
 	if !reflect.DeepEqual(m2.labels[0], l) {
 		t.Fatalf("labels not equal")
-	}
-}
-
-func TestFanoutSink_Sample(t *testing.T) {
-	m1 := &MockSink{}
-	m2 := &MockSink{}
-	fh := &FanoutSink{m1, m2}
-
-	k := []string{"test"}
-	v := float32(42.0)
-	fh.AddSample(k, v)
-
-	if !reflect.DeepEqual(m1.keys[0], k) {
-		t.Fatalf("key not equal")
-	}
-	if !reflect.DeepEqual(m2.keys[0], k) {
-		t.Fatalf("key not equal")
-	}
-	if !reflect.DeepEqual(m1.vals[0], v) {
-		t.Fatalf("val not equal")
-	}
-	if !reflect.DeepEqual(m2.vals[0], v) {
-		t.Fatalf("val not equal")
 	}
 }
 

--- a/statsd.go
+++ b/statsd.go
@@ -45,11 +45,6 @@ func (s *StatsdSink) Shutdown() {
 	close(s.metricQueue)
 }
 
-func (s *StatsdSink) SetGauge(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
-}
-
 func (s *StatsdSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
@@ -60,19 +55,9 @@ func (s *StatsdSink) EmitKey(key []string, val float32) {
 	s.pushMetric(fmt.Sprintf("%s:%f|kv\n", flatKey, val))
 }
 
-func (s *StatsdSink) IncrCounter(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
-}
-
 func (s *StatsdSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
-}
-
-func (s *StatsdSink) AddSample(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.pushMetric(fmt.Sprintf("%s:%f|ms\n", flatKey, val))
 }
 
 func (s *StatsdSink) AddSampleWithLabels(key []string, val float32, labels []Label) {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -117,12 +117,12 @@ func TestStatsd_Conn(t *testing.T) {
 		t.Fatalf("bad error")
 	}
 
-	s.SetGauge([]string{"gauge", "val"}, float32(1))
+	s.SetGaugeWithLabels([]string{"gauge", "val"}, float32(1), nil)
 	s.SetGaugeWithLabels([]string{"gauge_labels", "val"}, float32(2), []Label{{"a", "label"}})
 	s.EmitKey([]string{"key", "other"}, float32(3))
-	s.IncrCounter([]string{"counter", "me"}, float32(4))
+	s.IncrCounterWithLabels([]string{"counter", "me"}, float32(4), nil)
 	s.IncrCounterWithLabels([]string{"counter_labels", "me"}, float32(5), []Label{{"a", "label"}})
-	s.AddSample([]string{"sample", "slow thingy"}, float32(6))
+	s.AddSampleWithLabels([]string{"sample", "slow thingy"}, float32(6), nil)
 	s.AddSampleWithLabels([]string{"sample_labels", "slow thingy"}, float32(7), []Label{{"a", "label"}})
 
 	select {

--- a/statsite.go
+++ b/statsite.go
@@ -45,11 +45,6 @@ func (s *StatsiteSink) Shutdown() {
 	close(s.metricQueue)
 }
 
-func (s *StatsiteSink) SetGauge(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
-}
-
 func (s *StatsiteSink) SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
@@ -60,19 +55,9 @@ func (s *StatsiteSink) EmitKey(key []string, val float32) {
 	s.pushMetric(fmt.Sprintf("%s:%f|kv\n", flatKey, val))
 }
 
-func (s *StatsiteSink) IncrCounter(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
-}
-
 func (s *StatsiteSink) IncrCounterWithLabels(key []string, val float32, labels []Label) {
 	flatKey := s.flattenKeyLabels(key, labels)
 	s.pushMetric(fmt.Sprintf("%s:%f|c\n", flatKey, val))
-}
-
-func (s *StatsiteSink) AddSample(key []string, val float32) {
-	flatKey := s.flattenKey(key)
-	s.pushMetric(fmt.Sprintf("%s:%f|ms\n", flatKey, val))
 }
 
 func (s *StatsiteSink) AddSampleWithLabels(key []string, val float32, labels []Label) {

--- a/statsite_test.go
+++ b/statsite_test.go
@@ -114,12 +114,12 @@ func TestStatsite_Conn(t *testing.T) {
 		t.Fatalf("bad error")
 	}
 
-	s.SetGauge([]string{"gauge", "val"}, float32(1))
+	s.SetGaugeWithLabels([]string{"gauge", "val"}, float32(1), nil)
 	s.SetGaugeWithLabels([]string{"gauge_labels", "val"}, float32(2), []Label{{"a", "label"}})
 	s.EmitKey([]string{"key", "other"}, float32(3))
-	s.IncrCounter([]string{"counter", "me"}, float32(4))
+	s.IncrCounterWithLabels([]string{"counter", "me"}, float32(4), nil)
 	s.IncrCounterWithLabels([]string{"counter_labels", "me"}, float32(5), []Label{{"a", "label"}})
-	s.AddSample([]string{"sample", "slow thingy"}, float32(6))
+	s.AddSampleWithLabels([]string{"sample", "slow thingy"}, float32(6), nil)
 	s.AddSampleWithLabels([]string{"sample_labels", "slow thingy"}, float32(7), []Label{{"a", "label"}})
 
 	select {


### PR DESCRIPTION
With the addition of labels in #54 only the new `WithLabels` methods on `Sink` are used by `go-metrics`.

My understanding is that this should be a backwards compatible change, because `Sink` is the interface accepted by `metrics.New`. Implementations of a `Sink` outside of this package would continue to work, and new one would no longer need to implement the 3 unused methods. Nothing outside of this package should call the `Sink` methods directly, they would call the methods on `Metrics`, which have not changed.