### PR TITLE
Expose the global default metrics

### DIFF
--- a/start.go
+++ b/start.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-immutable-radix"
+	iradix "github.com/hashicorp/go-immutable-radix"
 )
 
 // Config is used to configure metrics settings
@@ -46,6 +46,11 @@ var globalMetrics atomic.Value // *Metrics
 func init() {
 	// Initialize to a blackhole sink to avoid errors
 	globalMetrics.Store(&Metrics{sink: &BlackholeSink{}})
+}
+
+// Default returns the shared global metrics instance.
+func Default() *Metrics {
+	return globalMetrics.Load().(*Metrics)
 }
 
 // DefaultConfig provides a sane default configuration


### PR DESCRIPTION
This should make it easier to test code that uses go-metrics. In tests the code can be passed a different instance of Metrics, and in production code paths it can use the global Metrics returned from Default().

Without this change patching the global can cause flaky tests when other tests attempt to emit metrics to the global metrics instance.

An example of this can be see in https://github.com/hashicorp/consul/pull/8679 which uses this change to fix a flaky test.

Prior art: https://pkg.go.dev/github.com/hashicorp/go-hclog?tab=doc#Default

cc @armon @banks 