### PR TITLE
Add {Gauge,Summary,Counter}Definitions to PrometheusOpts to define non-expiring metrics

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -199,7 +199,6 @@ func initGauges(m *sync.Map, gauges []GaugeDefinition) {
 			Help:        g.Help,
 			ConstLabels: prometheusLabels(g.ConstLabels),
 		})
-		pG.Set(float64(0)) // Initialize at zero
 		m.Store(hash, &gauge{ Gauge: pG })
 	}
 	return
@@ -215,7 +214,6 @@ func initSummaries(m *sync.Map, summaries []SummaryDefinition) {
 			ConstLabels: prometheusLabels(s.ConstLabels),
 			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
-		pS.Observe(float64(0)) // Initialize at zero
 		m.Store(hash, &summary{ Summary: pS })
 	}
 	return
@@ -229,7 +227,6 @@ func initCounters(m *sync.Map, counters []CounterDefinition) {
 			Help:        c.Help,
 			ConstLabels: prometheusLabels(c.ConstLabels),
 		})
-		pC.Add(float64(0)) // Initialize at zero
 		m.Store(hash, &counter{ Counter: pC })
 	}
 	return

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -211,7 +211,9 @@ func initSummaries(m *sync.Map, summaries []SummaryDefinition) {
 		pS := prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:        key,
 			Help:        s.Help,
+			MaxAge:      10 * time.Second,
 			ConstLabels: prometheusLabels(s.ConstLabels),
+			Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
 		pS.Observe(float64(0)) // Initialize at zero
 		m.Store(hash, &summary{ Summary: pS })

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -62,6 +62,7 @@ type PrometheusSink struct {
 type PrometheusGauge struct {
 	Name []string
 	ConstLabels []metrics.Label
+	Help string
 	prometheus.Gauge
 	updatedAt time.Time
 	// canDelete is set if the metric is created during runtime so we know it's ephemeral and can delete it on expiry.
@@ -71,6 +72,7 @@ type PrometheusGauge struct {
 type PrometheusSummary struct {
 	Name []string
 	ConstLabels []metrics.Label
+	Help string
 	prometheus.Summary
 	updatedAt time.Time
 	canDelete bool
@@ -79,6 +81,7 @@ type PrometheusSummary struct {
 type PrometheusCounter struct {
 	Name []string
 	ConstLabels []metrics.Label
+	Help string
 	prometheus.Counter
 	updatedAt time.Time
 	canDelete bool
@@ -174,7 +177,7 @@ func initGauges(m *sync.Map, gauges []PrometheusGauge) {
 		key, hash := flattenKey(gauge.Name, gauge.ConstLabels)
 		g := prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:        key,
-			Help:        key,
+			Help:        gauge.Help,
 			ConstLabels: prometheusLabels(gauge.ConstLabels),
 		})
 		g.Set(float64(0)) // Initialize at zero
@@ -189,7 +192,7 @@ func initSummaries(m *sync.Map, summaries []PrometheusSummary) {
 		key, hash := flattenKey(summary.Name, summary.ConstLabels)
 		s := prometheus.NewSummary(prometheus.SummaryOpts{
 			Name:        key,
-			Help:        key,
+			Help:        summary.Help,
 			ConstLabels: prometheusLabels(summary.ConstLabels),
 		})
 		s.Observe(float64(0)) // Initialize at zero
@@ -204,7 +207,7 @@ func initCounters(m *sync.Map, counters []PrometheusCounter) {
 		key, hash := flattenKey(counter.Name, counter.ConstLabels)
 		c := prometheus.NewCounter(prometheus.CounterOpts{
 			Name:        key,
-			Help:        key,
+			Help:        counter.Help,
 			ConstLabels: prometheusLabels(counter.ConstLabels),
 		})
 		c.Add(float64(0)) // Initialize at zero

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -31,8 +31,8 @@ type PrometheusOpts struct {
 	Expiration time.Duration
 	Registerer prometheus.Registerer
 
-	// Gauges, Summaries, and Counters allow us to pre-declare metrics by giving their Name and ConstLabels to the
-	// PrometheusSink when it is created. Metrics declared in this way will be initialized at zero and will not be
+	// Gauges, Summaries, and Counters allow us to pre-declare metrics by giving their Name, Help, and ConstLabels to
+	// the PrometheusSink when it is created. Metrics declared in this way will be initialized at zero and will not be
 	// deleted when their expiry is reached.
 	// - Gauges and Summaries will be set to NaN when they expire.
 	// - Counters continue to Collect their last known value.
@@ -42,6 +42,7 @@ type PrometheusOpts struct {
 	//     Gauges: []PrometheusGauge{
 	//         {
 	//	         Name: []string{ "application", "component", "measurement"},
+	//           Help: "application_component_measurement provides an example of how to declare static metrics",
 	//           ConstLabels: []metrics.Label{ { Name: "datacenter", Value: "dc1" }, },
 	//         },
 	//     },

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -157,7 +157,7 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 		if v != nil {
 			lastUpdate := v.(*PrometheusCounter).updatedAt
 			if expire && lastUpdate.Add(p.expiration).Before(now) {
-				if v.(PrometheusCounter).canDelete {
+				if v.(*PrometheusCounter).canDelete {
 					p.counters.Delete(k)
 					return true
 				}


### PR DESCRIPTION
This PR introduces structs for Gauge, Summary, and Counter Definitions that can be provided to the `PrometheusSink` via its `PrometheusOpts`. The `PrometheusSink` will uses these definition slices to declare metrics when the process starts, and marks them internally to _not_ be deleted when their last-updated time passes the configured expiry. Instead, if `canDelete` is `false`, the PrometheusSink expires the metric by setting its value to NaN. When metrics aren't defined, they should behave as they always have before this PR. 

Allowing go-metrics users to define static metrics in prometheus lets us resolve a [long-requested](https://github.com/hashicorp/consul/issues/8590) [pain](https://github.com/hashicorp/consul/issues/8181) [point](https://github.com/hashicorp/consul/issues/5140) with how Consul expires metrics it has not observed within its prometheus_retention_time, which we set PrometheusSink's expiry value with. Workarounds for this have led to users configuring retention times on the order of days, weeks, months, or longer, leading to a pathological loss of precision in metrics which do not update often. Not all of these metrics remain valid even if we haven't updated them. With this change we can recommend much shorter retention times which will lead to more accurate measurements and fewer bogus stats.

As a secondary benefit, we can provide prometheus users better UX by attaching help string documentation to the metrics, as prometheus users expect.

This is a successor PR to the approach in #119 and allows ephemeral metrics in HashiCorp products to continue to exist where short-lived metrics would otherwise stop products from adopting the previous NaNExpiry behavior wholesale. The definitions also provide a similar "define your metrics before you use them" approach that's used in Prometheus clients.

More research needs to be done on how to best handle definitions for sub-libraries using go-metrics which expect their configuration from their hosting application. One path offered by this PR is to declare definitions inside the library and have the hosting application "reach into" the lib and append its definitions to the application's when it creates its `PrometheusSink`. A alternative approach has been proposed which is compatible with this definitions PR, and was one of the early iterations on this bug fix: allow prometheus metrics to be "defined" at runtime with additional methods for each metric type in go-metrics. For one example, `InitCounterWithLabels`. 