### PR TITLE
Export emitRuntimeStats to provide a workaround for goroutine leak.

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -228,12 +228,12 @@ func (m *Metrics) allowMetric(key []string, labels []Label) (bool, []Label) {
 func (m *Metrics) collectStats() {
 	for {
 		time.Sleep(m.ProfileInterval)
-		m.emitRuntimeStats()
+		m.EmitRuntimeStats()
 	}
 }
 
 // Emits various runtime statsitics
-func (m *Metrics) emitRuntimeStats() {
+func (m *Metrics) EmitRuntimeStats() {
 	// Export number of Goroutines
 	numRoutines := runtime.NumGoroutine()
 	m.SetGauge([]string{"runtime", "num_goroutines"}, float32(numRoutines))

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -239,7 +239,7 @@ func TestMetrics_MeasureSince(t *testing.T) {
 func TestMetrics_EmitRuntimeStats(t *testing.T) {
 	runtime.GC()
 	m, met := mockMetric()
-	met.emitRuntimeStats()
+	met.EmitRuntimeStats()
 
 	if m.getKeys()[0][0] != "runtime" || m.getKeys()[0][1] != "num_goroutines" {
 		t.Fatalf("bad key %v", m.getKeys())


### PR DESCRIPTION
When EnableRuntimeMetrics is true, New will leak a goroutine that collects stats periodically.  Export the method that does the stats collection so that those who are willing to call it themselves can avoid that goroutine leak.