### PR TITLE
InmemSink: create a new RWMutex , because they are not safe to copy

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -245,6 +245,8 @@ func (i *InmemSink) Data() []*IntervalMetrics {
 	copyCurrent := intervals[n-1]
 	current.RLock()
 	*copyCurrent = *current
+	// RWMutex is not safe to copy, so create a new instance on the copy
+	copyCurrent.RWMutex = sync.RWMutex{}
 
 	copyCurrent.Gauges = make(map[string]GaugeValue, len(current.Gauges))
 	for k, v := range current.Gauges {


### PR DESCRIPTION
We noticed some Consul tests deadlock and timeout when run with the race detector ([example](https://app.circleci.com/pipelines/github/hashicorp/consul/18113/workflows/d9d32c2f-9adb-4171-8957-734f50786d70/jobs/358395/tests)). I tracked down the problem to this line in `InmemSink.Data`.

In 1d3de9f7002ebf98cf5c2a86cd03b0dbf1f8e885 there was a change made to fix some data races in this method. It looks like the `RWMutex` field was missed, possibly because the issue isn't a data race itself, so isn't reported by the race detector.

`RWMutex` are not safe for copying, so we need to create a new instance on the copy of `IntervalMetrics`.

Before this change I was able to pretty reliable cause the test to deadlock in under 200 runs. After this change the test no longer deadlocks after 1000+ runs. I haven't looked at the `RWMutex` internals, but I assume the docs mention they can not be copied for this reason.