### PR TITLE
inmem: allow streaming of metrics as intervals complete

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -69,6 +69,7 @@ func NewIntervalMetrics(intv time.Time) *IntervalMetrics {
 		Points:   make(map[string][]float32),
 		Counters: make(map[string]SampledValue),
 		Samples:  make(map[string]SampledValue),
+		done:     make(chan struct{}),
 	}
 }
 
@@ -301,8 +302,11 @@ func (i *InmemSink) getInterval() *IntervalMetrics {
 
 	current := NewIntervalMetrics(intv)
 	i.intervals = append(i.intervals, current)
-	n++
+	if n > 0 {
+		close(i.intervals[n-1].done)
+	}
 
+	n++
 	// Prune old intervals if the count exceeds the max.
 	if n >= i.maxIntervals {
 		copy(i.intervals[0:], i.intervals[n-i.maxIntervals:])

--- a/inmem.go
+++ b/inmem.go
@@ -55,6 +55,10 @@ type IntervalMetrics struct {
 	// Samples maps the key to an AggregateSample,
 	// which has the rolled up view of a sample
 	Samples map[string]SampledValue
+
+	// done is closed when this interval has ended, and a new IntervalMetrics
+	// has been created to receive any future metrics.
+	done chan struct{}
 }
 
 // NewIntervalMetrics creates a new IntervalMetrics for a given interval
@@ -270,47 +274,41 @@ func (i *InmemSink) Data() []*IntervalMetrics {
 	return intervals
 }
 
-func (i *InmemSink) getExistingInterval(intv time.Time) *IntervalMetrics {
-	i.intervalLock.RLock()
-	defer i.intervalLock.RUnlock()
+// getInterval returns the current interval. A new interval is created if no
+// previous interval exists, or if the current time is beyond the window for the
+// current interval.
+func (i *InmemSink) getInterval() *IntervalMetrics {
+	intv := time.Now().Truncate(i.interval)
 
+	// Attempt to return the existing interval first, because it only requires
+	// a read lock.
+	i.intervalLock.RLock()
 	n := len(i.intervals)
 	if n > 0 && i.intervals[n-1].Interval == intv {
+		defer i.intervalLock.RUnlock()
 		return i.intervals[n-1]
 	}
-	return nil
-}
+	i.intervalLock.RUnlock()
 
-func (i *InmemSink) createInterval(intv time.Time) *IntervalMetrics {
 	i.intervalLock.Lock()
 	defer i.intervalLock.Unlock()
 
-	// Check for an existing interval
-	n := len(i.intervals)
+	// Re-check for an existing interval now that the lock is re-acquired.
+	n = len(i.intervals)
 	if n > 0 && i.intervals[n-1].Interval == intv {
 		return i.intervals[n-1]
 	}
 
-	// Add the current interval
 	current := NewIntervalMetrics(intv)
 	i.intervals = append(i.intervals, current)
 	n++
 
-	// Truncate the intervals if they are too long
+	// Prune old intervals if the count exceeds the max.
 	if n >= i.maxIntervals {
 		copy(i.intervals[0:], i.intervals[n-i.maxIntervals:])
 		i.intervals = i.intervals[:i.maxIntervals]
 	}
 	return current
-}
-
-// getInterval returns the current interval to write to
-func (i *InmemSink) getInterval() *IntervalMetrics {
-	intv := time.Now().Truncate(i.interval)
-	if m := i.getExistingInterval(intv); m != nil {
-		return m
-	}
-	return i.createInterval(intv)
 }
 
 // Flattens the key for formatting, removes spaces

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -1,6 +1,10 @@
 package metrics
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -273,3 +277,62 @@ func TestDisplayMetrics_RaceMetricsSetGauge(t *testing.T) {
 	verify.Values(t, "all", got, float32(42))
 }
 
+func TestInmemSink_Stream(t *testing.T) {
+	interval := 10 * time.Millisecond
+	total := 50 * time.Millisecond
+	inm := NewInmemSink(interval, total)
+
+	ctx, cancel := context.WithTimeout(context.Background(), total*2)
+	defer cancel()
+
+	chDone := make(chan struct{})
+
+	go func() {
+		for i := float32(0); ctx.Err() == nil; i++ {
+			inm.SetGaugeWithLabels([]string{"gauge", "foo"}, 20+i, []Label{{"a", "b"}})
+			inm.EmitKey([]string{"key", "foo"}, 30+i)
+			inm.IncrCounterWithLabels([]string{"counter", "bar"}, 40+i, []Label{{"a", "b"}})
+			inm.IncrCounterWithLabels([]string{"counter", "bar"}, 50+i, []Label{{"a", "b"}})
+			inm.AddSampleWithLabels([]string{"sample", "bar"}, 60+i, []Label{{"a", "b"}})
+			inm.AddSampleWithLabels([]string{"sample", "bar"}, 70+i, []Label{{"a", "b"}})
+			time.Sleep(interval / 3)
+		}
+		close(chDone)
+	}()
+
+	resp := httptest.NewRecorder()
+	logger := stdoutLogger{}
+	inm.Stream(ctx, logger, resp)
+
+	<-chDone
+
+	decoder := json.NewDecoder(resp.Body)
+	var prevGaugeValue float32
+	for i := 0; i < 8; i++ {
+		var summary MetricsSummary
+		if err := decoder.Decode(&summary); err != nil {
+			t.Fatalf("expected no error while decoding response %d, got %v", i, err)
+		}
+		if count := len(summary.Gauges); count != 1 {
+			t.Fatalf("expected at least one gauge in response %d, got %v", i, count)
+		}
+		value := summary.Gauges[0].Value
+		// The upper bound of the gauge value is not known, but we can expect it
+		// to be less than 50 because it increments by 3 every interval and we run
+		// for ~10 intervals.
+		if value < 20 || value > 50 {
+			t.Fatalf("expected interval %d guage value between 20 and 50, got %v", i, value)
+		}
+		if value <= prevGaugeValue {
+			t.Fatalf("expected interval %d guage value to be greater than previous, %v == %v", i, value, prevGaugeValue)
+		}
+		prevGaugeValue = value
+	}
+}
+
+type stdoutLogger struct{}
+
+func (stdoutLogger) Warn(msg string, args ...interface{}) {
+	fmt.Print(msg)
+	fmt.Println(args...)
+}


### PR DESCRIPTION
Related to one of the items in https://github.com/hashicorp/consul/issues/10320

We use the `InMemSink` to capture metrics for the debug archive, but the previous implementation resulted in us missing a lot of metrics because only 1/3 of the intervals were captured. Attempting to request the metrics at each interval is a challenge (maybe impossible), so instead this PR adds for an HTTP handler that sends metrics each time an interval completes.