### PR TITLE
Refactor Shutdown into a separate interface to revert breaking change.

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -230,10 +230,6 @@ func (i *InmemSink) AddSampleWithLabels(key []string, val float32, labels []Labe
 	agg.Ingest(float64(val), i.rateDenom)
 }
 
-func (i *InmemSink) Shutdown() {
-	// Do nothing. InmemSink does not have cleanup associated with shutdown.
-}
-
 // Data is used to retrieve all the aggregated metrics
 // Intervals may be in use, and a read lock should be acquired
 func (i *InmemSink) Data() []*IntervalMetrics {

--- a/metrics.go
+++ b/metrics.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-immutable-radix"
+	iradix "github.com/hashicorp/go-immutable-radix"
 )
 
 type Label struct {
@@ -173,7 +173,9 @@ func (m *Metrics) UpdateFilterAndLabels(allow, block, allowedLabels, blockedLabe
 }
 
 func (m *Metrics) Shutdown() {
-	m.sink.Shutdown()
+	if ss, ok := m.sink.(ShutdownSink); ok {
+		ss.Shutdown()
+	}
 }
 
 // labelIsAllowed return true if a should be included in metric

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -394,10 +394,6 @@ func (p *PrometheusSink) IncrCounterWithLabels(parts []string, val float32, labe
 	}
 }
 
-// Shutdown is not implemented. PrometheusSink is in memory storage.
-func (p *PrometheusSink) Shutdown() {
-}
-
 // PrometheusPushSink wraps a normal prometheus sink and provides an address and facilities to export it to an address
 // on an interval.
 type PrometheusPushSink struct {


### PR DESCRIPTION
#132 Added a new `Shutdown` method that solves a specific problem with short-lived processes.

Unfortunately since it added a new method to a public interface it broke backwards compatibility for other users of this library. We retracted the release v0.3.11 in #134.

Technically this library is still "zerover" since it's not yet made it to the 1.0.0 milestone and likely never will, but it is used widely in HashiCorp tools so it's preferable not to break downstream builds!

This PR moves the new `Shutdown` method into a separate interface that can be optionally implemented by Sinks. I also remove all the no-op implementations for built-in Sinks since they are not longer necessary.

@ggambetti would love to know if this will cause any issues for you? I think it should be compatible and tests all pass as before.