### PR TITLE
compliance: fix invalid team from `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,1 @@
-# Each line is a file pattern followed by one or more owners.
-# More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
-
-# Default owner
-* @hashicorp/nomad-eng @hashicorp/consul-core @hashicorp/vault-core
-
-# Add override rules below. Each line is a file/folder pattern followed by one or more owners.
-# Being an owner means those groups or individuals will be added as reviewers to PRs affecting
-# those areas of the code.
-# Examples:
-# /docs/  @docs-team
-# *.js    @js-team
-# *.go    @go-team
+* @hashicorp/nomad-eng @hashicorp/consul-core @hashicorp/vault


### PR DESCRIPTION
 The team for Vault should be `@hashicorp/vault` and not `@hashicorp/vault-core`, so fix this to avoid the compliance scan complaining and posting "high severity" Jiras about it.

Fixes: https://hashicorp.atlassian.net/browse/SECVULN-45540

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->