### PR TITLE
prometheus: periodically clear expired metrics

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -6,10 +6,12 @@
 package prometheus
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-metrics"
@@ -56,12 +58,13 @@ type PrometheusOpts struct {
 
 type PrometheusSink struct {
 	// If these will ever be copied, they should be converted to *sync.Map values and initialized appropriately
-	gauges     sync.Map
-	summaries  sync.Map
-	counters   sync.Map
-	expiration time.Duration
-	help       map[string]string
-	name       string
+	gauges         sync.Map
+	summaries      sync.Map
+	counters       sync.Map
+	expiration     time.Duration
+	lastCollection atomic.Int64
+	help           map[string]string
+	name           string
 }
 
 // GaugeDefinition can be provided to PrometheusOpts to declare a constant gauge that is not deleted on expiry.
@@ -116,12 +119,13 @@ func NewPrometheusSinkFrom(opts PrometheusOpts) (*PrometheusSink, error) {
 		name = "default_prometheus_sink"
 	}
 	sink := &PrometheusSink{
-		gauges:     sync.Map{},
-		summaries:  sync.Map{},
-		counters:   sync.Map{},
-		expiration: opts.Expiration,
-		help:       make(map[string]string),
-		name:       name,
+		gauges:         sync.Map{},
+		summaries:      sync.Map{},
+		counters:       sync.Map{},
+		expiration:     opts.Expiration,
+		lastCollection: atomic.Int64{},
+		help:           make(map[string]string),
+		name:           name,
 	}
 
 	initGauges(&sink.gauges, opts.GaugeDefinitions, sink.help)
@@ -157,6 +161,7 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 // collectAtTime allows internal testing of the expiry based logic here without
 // mocking clocks or making tests timing sensitive.
 func (p *PrometheusSink) collectAtTime(c chan<- prometheus.Metric, t time.Time) {
+	p.lastCollection.Store(t.UnixNano())
 	expire := p.expiration != 0
 	p.gauges.Range(func(k, v interface{}) bool {
 		if v == nil {
@@ -201,6 +206,82 @@ func (p *PrometheusSink) collectAtTime(c chan<- prometheus.Metric, t time.Time) 
 			}
 		}
 		count.Collect(c)
+		return true
+	})
+}
+
+// RunBackgroundCleanup starts a background goroutine that periodically removes
+// expired metrics if it's been more than twice the expiration interval since
+// last collection. This ensures metrics are cleaned up even when the endpoint
+// is not being scraped to avoid resource leaks
+func (p *PrometheusSink) RunBackgroundCleanup(ctx context.Context) {
+	if p.expiration == 0 {
+		return
+	}
+	interval := p.expiration
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				last := time.Unix(0, p.lastCollection.Load())
+				if time.Since(last) > interval*2 {
+					p.cleanupExpiredAt(time.Now())
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (p *PrometheusSink) cleanupExpiredAt(t time.Time) {
+	if p.expiration == 0 {
+		return
+	}
+
+	p.gauges.Range(func(k, v any) bool {
+		if v == nil {
+			return true
+		}
+		g := v.(*gauge)
+		lastUpdate := g.updatedAt
+		if lastUpdate.Add(p.expiration).Before(t) {
+			if g.canDelete {
+				p.gauges.Delete(k)
+				return true
+			}
+		}
+		return true
+	})
+	p.summaries.Range(func(k, v any) bool {
+		if v == nil {
+			return true
+		}
+		s := v.(*summary)
+		lastUpdate := s.updatedAt
+		if lastUpdate.Add(p.expiration).Before(t) {
+			if s.canDelete {
+				p.summaries.Delete(k)
+				return true
+			}
+		}
+		return true
+	})
+	p.counters.Range(func(k, v any) bool {
+		if v == nil {
+			return true
+		}
+		count := v.(*counter)
+		lastUpdate := count.updatedAt
+		if lastUpdate.Add(p.expiration).Before(t) {
+			if count.canDelete {
+				p.counters.Delete(k)
+				return true
+			}
+		}
 		return true
 	})
 }

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -159,7 +159,8 @@ func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
 }
 
 // collectAtTime allows internal testing of the expiry based logic here without
-// mocking clocks or making tests timing sensitive.
+// mocking clocks or making tests timing sensitive. fn is the collection
+// callback that's called for each unexpired metric
 func (p *PrometheusSink) collectAtTime(fn func(prometheus.Collector), t time.Time) {
 	p.lastCollection.Store(t.UnixNano())
 	expire := p.expiration != 0

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -237,6 +237,9 @@ func (p *PrometheusSink) RunBackgroundCleanup(ctx context.Context) {
 	}()
 }
 
+// cleanupExpiredAt deletes expired metrics. Since collection 
+// also deletes expired metrics, changes to one method often
+// require changes to the other.
 func (p *PrometheusSink) cleanupExpiredAt(t time.Time) {
 	if p.expiration == 0 {
 		return

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -155,12 +155,12 @@ func (p *PrometheusSink) Describe(c chan<- *prometheus.Desc) {
 // logic to clean up ephemeral metrics if their value haven't been set for a
 // duration exceeding our allowed expiration time.
 func (p *PrometheusSink) Collect(c chan<- prometheus.Metric) {
-	p.collectAtTime(c, time.Now())
+	p.collectAtTime(func(p prometheus.Collector) { p.Collect(c) }, time.Now())
 }
 
 // collectAtTime allows internal testing of the expiry based logic here without
 // mocking clocks or making tests timing sensitive.
-func (p *PrometheusSink) collectAtTime(c chan<- prometheus.Metric, t time.Time) {
+func (p *PrometheusSink) collectAtTime(fn func(prometheus.Collector), t time.Time) {
 	p.lastCollection.Store(t.UnixNano())
 	expire := p.expiration != 0
 	p.gauges.Range(func(k, v interface{}) bool {
@@ -175,7 +175,7 @@ func (p *PrometheusSink) collectAtTime(c chan<- prometheus.Metric, t time.Time) 
 				return true
 			}
 		}
-		g.Collect(c)
+		fn(g)
 		return true
 	})
 	p.summaries.Range(func(k, v interface{}) bool {
@@ -190,7 +190,7 @@ func (p *PrometheusSink) collectAtTime(c chan<- prometheus.Metric, t time.Time) 
 				return true
 			}
 		}
-		s.Collect(c)
+		fn(s)
 		return true
 	})
 	p.counters.Range(func(k, v interface{}) bool {
@@ -205,7 +205,7 @@ func (p *PrometheusSink) collectAtTime(c chan<- prometheus.Metric, t time.Time) 
 				return true
 			}
 		}
-		count.Collect(c)
+		fn(count)
 		return true
 	})
 }
@@ -228,65 +228,13 @@ func (p *PrometheusSink) RunBackgroundCleanup(ctx context.Context) {
 			case <-ticker.C:
 				last := time.Unix(0, p.lastCollection.Load())
 				if time.Since(last) > interval*2 {
-					p.cleanupExpiredAt(time.Now())
+					p.collectAtTime(func(prometheus.Collector) {}, time.Now())
 				}
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-}
-
-// cleanupExpiredAt deletes expired metrics. Since collection 
-// also deletes expired metrics, changes to one method often
-// require changes to the other.
-func (p *PrometheusSink) cleanupExpiredAt(t time.Time) {
-	if p.expiration == 0 {
-		return
-	}
-
-	p.gauges.Range(func(k, v any) bool {
-		if v == nil {
-			return true
-		}
-		g := v.(*gauge)
-		lastUpdate := g.updatedAt
-		if lastUpdate.Add(p.expiration).Before(t) {
-			if g.canDelete {
-				p.gauges.Delete(k)
-				return true
-			}
-		}
-		return true
-	})
-	p.summaries.Range(func(k, v any) bool {
-		if v == nil {
-			return true
-		}
-		s := v.(*summary)
-		lastUpdate := s.updatedAt
-		if lastUpdate.Add(p.expiration).Before(t) {
-			if s.canDelete {
-				p.summaries.Delete(k)
-				return true
-			}
-		}
-		return true
-	})
-	p.counters.Range(func(k, v any) bool {
-		if v == nil {
-			return true
-		}
-		count := v.(*counter)
-		lastUpdate := count.updatedAt
-		if lastUpdate.Add(p.expiration).Before(t) {
-			if count.canDelete {
-				p.counters.Delete(k)
-				return true
-			}
-		}
-		return true
-	})
 }
 
 func initGauges(m *sync.Map, gauges []GaugeDefinition, help map[string]string) {

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -238,7 +238,8 @@ func TestDefinitions(t *testing.T) {
 
 	// Collect the metrics as if it's some time in the future, way beyond the 5
 	// second expiry.
-	sink.collectAtTime(ch, timeAfterUpdates.Add(10*time.Second))
+	sink.collectAtTime(func(c prometheus.Collector) { c.Collect(ch) },
+		timeAfterUpdates.Add(10*time.Second))
 
 	// We should see all the metrics desired Expiry behavior
 	expectedNum := 3

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -4,6 +4,7 @@
 package prometheus
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -112,6 +113,59 @@ func TestMultiplePrometheusSink(t *testing.T) {
 	if !ok {
 		t.Fatalf("Unregister(sink) = false, want true")
 	}
+}
+
+func TestPrometheusSink_BackgroundGC(t *testing.T) {
+	sink, err := NewPrometheusSinkFrom(PrometheusOpts{
+		Expiration: time.Millisecond * 10,
+		Name:       "test_sink",
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+
+	parts := []string{"one", "two"}
+
+	metricsConf := metrics.DefaultConfig("default")
+	metricsConf.HostName = MockGetHostname()
+	metricsConf.EnableHostnameLabel = true
+	_, _ = metrics.NewGlobal(metricsConf, sink)
+	metrics.SetPrecisionGauge(parts, 42)
+
+	var found bool
+	sink.gauges.Range(func(key, val any) bool {
+		if key != "default_one_two;host=test_hostname" {
+			t.Fatal("expected metric")
+		}
+		found = true
+		return true
+	})
+	if !found {
+		t.Fatalf("expected a metric")
+	}
+	ctx, cancel := context.WithTimeout(context.TODO(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+	sink.RunBackgroundCleanup(ctx)
+
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("metrics should have been GC'd")
+		case <-ticker.C:
+			found := false
+			sink.gauges.Range(func(key, val any) bool {
+				found = true
+				return true
+			})
+			if !found {
+				return
+			}
+		}
+	}
+
 }
 
 func TestDefinitions(t *testing.T) {


### PR DESCRIPTION
The Prometheus sink clears expired metrics when they're collected. But this means that if a metrics collector fails, metrics will accumulate in the sink and consume potentially large amounts of memory. This has been implicated in a number of reported problems with Nomad as well as internal incidents.

Allow consumers to spin up a background goroutine on the sink that periodically GCs expired metrics if no collection has happened for longer than twice the expiry.

Ref: https://github.com/hashicorp/nomad/issues/27013
Ref: https://github.com/hashicorp/nomad/issues/18113
Ref: https://hashicorp.atlassian.net/browse/NMD-1059
Ref: https://hashicorp.atlassian.net/browse/NMD-555
Ref: `#hashi-inc-8583`

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->