### PR TITLE
remove test dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/armon/go-metrics v0.4.1
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
 	github.com/hashicorp/go-immutable-radix v1.0.0
-	github.com/pascaldekloe/goe v0.1.0
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0

--- a/inmem_endpoint_test.go
+++ b/inmem_endpoint_test.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
-
-	"github.com/pascaldekloe/goe/verify"
 )
 
 func TestDisplayMetrics(t *testing.T) {
@@ -38,7 +37,8 @@ func TestDisplayMetrics(t *testing.T) {
 	}
 
 	expected := MetricsSummary{
-		Timestamp: data[0].Interval.Round(time.Second).UTC().String(),
+		Timestamp:       data[0].Interval.Round(time.Second).UTC().String(),
+		PrecisionGauges: make([]PrecisionGaugeValue, 0),
 		Gauges: []GaugeValue{
 			{
 				Name:          "foo.bar",
@@ -71,8 +71,9 @@ func TestDisplayMetrics(t *testing.T) {
 					SumSq: 884,
 					Rate:  4200,
 				},
-				Mean:   21,
-				Stddev: 1.4142135623730951,
+				Mean:          21,
+				Stddev:        1.4142135623730951,
+				DisplayLabels: make(map[string]string),
 			},
 			{
 				Name: "foo.bar",
@@ -102,8 +103,9 @@ func TestDisplayMetrics(t *testing.T) {
 					SumSq: 976,
 					Rate:  4400,
 				},
-				Mean:   22,
-				Stddev: 2.8284271247461903,
+				Mean:          22,
+				Stddev:        2.8284271247461903,
+				DisplayLabels: make(map[string]string),
 			},
 			{
 				Name: "foo.bar",
@@ -137,7 +139,9 @@ func TestDisplayMetrics(t *testing.T) {
 		expected.Samples[i].LastUpdated = got.LastUpdated
 	}
 
-	verify.Values(t, "all", result, expected)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("")
+	}
 }
 
 func TestDisplayMetrics_RaceSetGauge(t *testing.T) {
@@ -171,7 +175,9 @@ func TestDisplayMetrics_RaceSetGauge(t *testing.T) {
 	}()
 
 	got := <-result
-	verify.Values(t, "all", got, float32(42))
+	if got != 42 {
+		t.Fatalf("expected 42, got %v", got)
+	}
 }
 
 func TestDisplayMetrics_RaceAddSample(t *testing.T) {
@@ -205,7 +211,9 @@ func TestDisplayMetrics_RaceAddSample(t *testing.T) {
 	}()
 
 	got := <-result
-	verify.Values(t, "all", got, float32(0.0))
+	if got != 0.0 {
+		t.Fatalf("expected 0.0, got %v", got)
+	}
 }
 
 func TestDisplayMetrics_RaceIncrCounter(t *testing.T) {
@@ -239,7 +247,9 @@ func TestDisplayMetrics_RaceIncrCounter(t *testing.T) {
 	}()
 
 	got := <-result
-	verify.Values(t, "all", got, float32(0.0))
+	if got != 0.0 {
+		t.Fatalf("expected 0.0, got %v", got)
+	}
 }
 
 func TestDisplayMetrics_RaceMetricsSetGauge(t *testing.T) {
@@ -278,7 +288,9 @@ func TestDisplayMetrics_RaceMetricsSetGauge(t *testing.T) {
 	}()
 
 	got := <-result
-	verify.Values(t, "all", got, float32(42))
+	if got != 42 {
+		t.Fatalf("expected 42, got %v", got)
+	}
 }
 
 func TestInmemSink_Stream(t *testing.T) {


### PR DESCRIPTION
https://github.com/hashicorp/go-metrics/pull/163 removes a fairly useless test-only dependency. The PR was neglected by us maintainers and now has merge conflicts, but the PR was not configured to allow maintainer force-pushes. Rather than wasting more of the contributor's time, this PR cherry-picks the author's work into a new PR.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->