### PR TITLE
update go.mod to current oldstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-## Unreleased
-
-### Improvements
-
-### Changes
-
-### Fixed
-
-### Security

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/go-metrics
 
-go 1.23.0
+go 1.25
 
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible


### PR DESCRIPTION
Ahead of tagging a 0.6.0 release, update the go.mod to use the current oldstable build. Also remove unused changelog file

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->