### PR TITLE
VAULT-48025: fixing telemetry statsd/statsite sink and formatting errors

### DIFF
--- a/compat/hashicorp.go
+++ b/compat/hashicorp.go
@@ -122,10 +122,20 @@ func NewGlobal(conf *Config, sink MetricSink) (*Metrics, error) {
 	return metrics.NewGlobal(conf, sink)
 }
 
+type SinkLogger = metrics.SinkLogger
+
 func NewStatsdSink(addr string) (*StatsdSink, error) {
 	return metrics.NewStatsdSink(addr)
 }
 
+func NewStatsdSinkWithLogger(addr string, logger SinkLogger) (*StatsdSink, error) {
+	return metrics.NewStatsdSinkWithLogger(addr, logger)
+}
+
 func NewStatsiteSink(addr string) (*StatsiteSink, error) {
 	return metrics.NewStatsiteSink(addr)
+}
+
+func NewStatsiteSinkWithLogger(addr string, logger SinkLogger) (*StatsiteSink, error) {
+	return metrics.NewStatsiteSinkWithLogger(addr, logger)
 }

--- a/compat/hashicorp.go
+++ b/compat/hashicorp.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MIT
 
 //go:build hashicorpmetrics

--- a/statsd.go
+++ b/statsd.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MIT
 
 package metrics

--- a/statsd.go
+++ b/statsd.go
@@ -19,12 +19,22 @@ const (
 	statsdMaxLen = 1400
 )
 
+// SinkLogger is a minimal structured logging interface that sink implementations
+// use to emit operational error messages. It is satisfied by hclog.Logger and
+// any other structured logger that provides Warn and Error methods with
+// key/value pair arguments.
+type SinkLogger interface {
+	Warn(msg string, args ...interface{})
+	Error(msg string, args ...interface{})
+}
+
 // StatsdSink provides a MetricSink that can be used
 // with a statsite or statsd metrics server. It uses
 // only UDP packets, while StatsiteSink uses TCP.
 type StatsdSink struct {
 	addr        string
 	metricQueue chan string
+	logger      SinkLogger
 }
 
 // NewStatsdSinkFromURL creates an StatsdSink from a URL. It is used
@@ -41,6 +51,47 @@ func NewStatsdSink(addr string) (*StatsdSink, error) {
 	}
 	go s.flushMetrics()
 	return s, nil
+}
+
+// NewStatsdSinkWithLogger is used to create a new StatsdSink with a SinkLogger.
+// The logger is set before the background flush goroutine starts, ensuring all
+// operational errors are routed through it from the first connection attempt.
+func NewStatsdSinkWithLogger(addr string, logger SinkLogger) (*StatsdSink, error) {
+	s := &StatsdSink{
+		addr:        addr,
+		metricQueue: make(chan string, 4096),
+		logger:      logger,
+	}
+	go s.flushMetrics()
+	return s, nil
+}
+
+// SetLogger assigns a SinkLogger to the sink. When set, operational errors
+// such as connection failures and flush errors are emitted through the provided
+// logger instead of the stdlib log package, allowing callers to control the
+// log format and destination.
+func (s *StatsdSink) SetLogger(logger SinkLogger) {
+	s.logger = logger
+}
+
+// logWarn emits a warning through the configured SinkLogger when one is set,
+// falling back to stdlib log.Printf otherwise.
+func (s *StatsdSink) logWarn(msg string, err error) {
+	if s.logger != nil {
+		s.logger.Warn(msg, "error", err)
+	} else {
+		log.Printf("[WARN] %s Err: %s", msg, err)
+	}
+}
+
+// logErr emits an error through the configured SinkLogger when one is set,
+// falling back to stdlib log.Printf otherwise.
+func (s *StatsdSink) logErr(msg string, err error) {
+	if s.logger != nil {
+		s.logger.Error(msg, "error", err)
+	} else {
+		log.Printf("[ERR] %s Err: %s", msg, err)
+	}
 }
 
 // Close is used to stop flushing to statsd
@@ -139,7 +190,7 @@ CONNECT:
 	// Attempt to connect
 	sock, err = net.Dial("udp", s.addr)
 	if err != nil {
-		log.Printf("[ERR] Error connecting to statsd! Err: %s", err)
+		s.logErr("Error connecting to statsd!", err)
 		goto WAIT
 	}
 
@@ -156,7 +207,7 @@ CONNECT:
 				_, err := sock.Write(buf.Bytes())
 				buf.Reset()
 				if err != nil {
-					log.Printf("[ERR] Error writing to statsd! Err: %s", err)
+					s.logErr("Error writing to statsd!", err)
 					goto WAIT
 				}
 			}
@@ -172,7 +223,7 @@ CONNECT:
 			_, err := sock.Write(buf.Bytes())
 			buf.Reset()
 			if err != nil {
-				log.Printf("[ERR] Error flushing to statsd! Err: %s", err)
+				s.logErr("Error flushing to statsd!", err)
 				goto WAIT
 			}
 		}

--- a/statsd.go
+++ b/statsd.go
@@ -24,8 +24,8 @@ const (
 // any other structured logger that provides Warn and Error methods with
 // key/value pair arguments.
 type SinkLogger interface {
-	Warn(msg string, args ...interface{})
-	Error(msg string, args ...interface{})
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
 }
 
 // StatsdSink provides a MetricSink that can be used

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MIT
 
 package metrics

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -21,13 +21,13 @@ type testLogger struct {
 	errors  []string
 }
 
-func (l *testLogger) Warn(msg string, args ...interface{}) {
+func (l *testLogger) Warn(msg string, args ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.warns = append(l.warns, msg)
 }
 
-func (l *testLogger) Error(msg string, args ...interface{}) {
+func (l *testLogger) Error(msg string, args ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.errors = append(l.errors, msg)

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -10,9 +10,28 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+type testLogger struct {
+	mu      sync.Mutex
+	warns   []string
+	errors  []string
+}
+
+func (l *testLogger) Warn(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, msg)
+}
+
+func (l *testLogger) Error(msg string, args ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, msg)
+}
 
 func TestStatsd_Flatten(t *testing.T) {
 	s := &StatsdSink{}
@@ -214,4 +233,42 @@ func TestNewStatsdSinkFromURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStatsdSink_SetLogger_ConnectError(t *testing.T) {
+	logger := &testLogger{}
+
+	s := &StatsdSink{
+		addr:        "127.0.0.1:1",
+		metricQueue: make(chan string, 4096),
+		logger:      logger,
+	}
+
+	s.logErr("Error connecting to statsd!", fmt.Errorf("connection refused"))
+	s.logErr("Error writing to statsd!", fmt.Errorf("write error"))
+	s.logErr("Error flushing to statsd!", fmt.Errorf("flush error"))
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	if len(logger.errors) != 3 {
+		t.Fatalf("expected 3 errors logged via SinkLogger, got %d", len(logger.errors))
+	}
+	for i, want := range []string{
+		"Error connecting to statsd!",
+		"Error writing to statsd!",
+		"Error flushing to statsd!",
+	} {
+		if logger.errors[i] != want {
+			t.Errorf("error[%d]: got %q, want %q", i, logger.errors[i], want)
+		}
+	}
+}
+
+func TestStatsdSink_SetLogger_NilFallback(t *testing.T) {
+	s := &StatsdSink{}
+	if s.logger != nil {
+		t.Fatal("expected nil logger by default")
+	}
+	s.logErr("test error", fmt.Errorf("err"))
+	s.logWarn("test warn", fmt.Errorf("warn"))
 }

--- a/statsite.go
+++ b/statsite.go
@@ -31,6 +31,7 @@ func NewStatsiteSinkFromURL(u *url.URL) (MetricSink, error) {
 type StatsiteSink struct {
 	addr        string
 	metricQueue chan string
+	logger      SinkLogger
 }
 
 // NewStatsiteSink is used to create a new StatsiteSink
@@ -41,6 +42,47 @@ func NewStatsiteSink(addr string) (*StatsiteSink, error) {
 	}
 	go s.flushMetrics()
 	return s, nil
+}
+
+// NewStatsiteSinkWithLogger is used to create a new StatsiteSink with a SinkLogger.
+// The logger is set before the background flush goroutine starts, ensuring all
+// operational errors are routed through it from the first connection attempt.
+func NewStatsiteSinkWithLogger(addr string, logger SinkLogger) (*StatsiteSink, error) {
+	s := &StatsiteSink{
+		addr:        addr,
+		metricQueue: make(chan string, 4096),
+		logger:      logger,
+	}
+	go s.flushMetrics()
+	return s, nil
+}
+
+// SetLogger assigns a SinkLogger to the sink. When set, operational errors
+// such as connection failures and flush errors are emitted through the provided
+// logger instead of the stdlib log package, allowing callers to control the
+// log format and destination.
+func (s *StatsiteSink) SetLogger(logger SinkLogger) {
+	s.logger = logger
+}
+
+// logWarn emits a warning through the configured SinkLogger when one is set,
+// falling back to stdlib log.Printf otherwise.
+func (s *StatsiteSink) logWarn(msg string, err error) {
+	if s.logger != nil {
+		s.logger.Warn(msg, "error", err)
+	} else {
+		log.Printf("[WARN] %s Err: %s", msg, err)
+	}
+}
+
+// logErr emits an error through the configured SinkLogger when one is set,
+// falling back to stdlib log.Printf otherwise.
+func (s *StatsiteSink) logErr(msg string, err error) {
+	if s.logger != nil {
+		s.logger.Error(msg, "error", err)
+	} else {
+		log.Printf("[ERR] %s Err: %s", msg, err)
+	}
 }
 
 // Close is used to stop flushing to statsite
@@ -137,7 +179,7 @@ CONNECT:
 	// Attempt to connect
 	sock, err = net.Dial("tcp", s.addr)
 	if err != nil {
-		log.Printf("[ERR] Error connecting to statsite! Err: %s", err)
+		s.logErr("Error connecting to statsite!", err)
 		goto WAIT
 	}
 
@@ -155,12 +197,12 @@ CONNECT:
 			// Try to send to statsite
 			_, err := buffered.Write([]byte(metric))
 			if err != nil {
-				log.Printf("[ERR] Error writing to statsite! Err: %s", err)
+				s.logErr("Error writing to statsite!", err)
 				goto WAIT
 			}
 		case <-ticker.C:
 			if err := buffered.Flush(); err != nil {
-				log.Printf("[ERR] Error flushing to statsite! Err: %s", err)
+				s.logErr("Error flushing to statsite!", err)
 				goto WAIT
 			}
 		}

--- a/statsite.go
+++ b/statsite.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MIT
 
 package metrics

--- a/statsite_test.go
+++ b/statsite_test.go
@@ -214,3 +214,41 @@ func TestNewStatsiteSinkFromURL(t *testing.T) {
 		})
 	}
 }
+
+func TestStatsiteSink_SetLogger_ConnectError(t *testing.T) {
+	logger := &testLogger{}
+
+	s, err := NewStatsiteSinkWithLogger("127.0.0.1:1", logger)
+	if err != nil {
+		t.Fatalf("unexpected err: %s", err)
+	}
+	defer s.Shutdown()
+
+	s.SetGauge([]string{"test", "gauge"}, float32(1))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		logger.mu.Lock()
+		errCount := len(logger.errors)
+		logger.mu.Unlock()
+		if errCount > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	if len(logger.errors) == 0 {
+		t.Fatal("expected at least one error to be logged via SinkLogger, got none")
+	}
+}
+
+func TestStatsiteSink_SetLogger_NilFallback(t *testing.T) {
+	s := &StatsiteSink{}
+	if s.logger != nil {
+		t.Fatal("expected nil logger by default")
+	}
+	s.logErr("test error", fmt.Errorf("err"))
+	s.logWarn("test warn", fmt.Errorf("warn"))
+}

--- a/statsite_test.go
+++ b/statsite_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2013, 2025
+// Copyright IBM Corp. 2013, 2026
 // SPDX-License-Identifier: MIT
 
 package metrics


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description
- VAULT-48025: fixing telemetry statsd/statsite sink and formatting errors are part of this gh issue: https://github.com/hashicorp/vault/issues/29188
- Added two new sinks so formatting is correct (e.g. format = json) 
- Ensured to leave the existing sinks to not break any current dependencies

<!-- Provide a summary of what the PR does and why it is being submitted. -->

## Related Issue

<!-- If this PR is linked to any issue, provide the issue number or description here. Any related JIRA tickets can also be added here. -->

## How Has This Been Tested?

<!-- Describe how the changes have been tested. Provide test instructions or details. -->

- This has been tested locally against the Vault-ent repo and uploaded to the [JIRA](https://hashicorp.atlassian.net/browse/VAULT-48025) 
